### PR TITLE
Changed HTML-serving endpoints to only serve HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,20 @@ git clone https://github.com/stellar/django-polaris.git
 cd django-polaris
 pipenv install --dev
 ```
-To test:
+### Git Flow
+At the time of writing this, the latest public release is v0.9. 
+After each release, a new development branch is created for the next upcoming release. In this case, that is 0.9.1.dev.
+Follow the instructions below to submit a valid pull request.
+
+1. Checkout the current development branch (0.9.1.dev) (`git checkout`)
+1. Create a new branch based off the latest dev branch (`git checkout -b`)
+1. Make your changes (`git add .; git commit -m`)
+1. Push your changes to a new remote branch matching your local branch (`git push --set-upstream origin`)
+1. Create a pull request based off the current dev branch
+    1. If the latest dev branch has changed, rebase your branch on the new dev branch (`git fetch; git rebase`)
+
+
+### Testing
 ```.env
-pipenv run python polaris/manage.py collectstatic --no-input
 pipenv run pytest
-```
-Note: `collectstatic` removes some files and generates others. Make sure these changes don't make it into your PR. You can remove the files generated using:
-```
-pipenv run python polaris/manage.py collectstatic --clear
 ```

--- a/polaris/polaris/fee/views.py
+++ b/polaris/polaris/fee/views.py
@@ -21,8 +21,8 @@ def _op_type_is_valid(asset_code: str, operation: str, op_type: str) -> bool:
     return False
 
 
-@validate_sep10_token()
 @api_view()
+@validate_sep10_token()
 def fee(request):
     """
     Definition of the /fee endpoint, in accordance with SEP-0024.

--- a/polaris/polaris/helpers.py
+++ b/polaris/polaris/helpers.py
@@ -28,10 +28,22 @@ def calc_fee(asset: Asset, operation: str, amount: float) -> float:
     return fee_fixed + (fee_percent / 100.0) * amount
 
 
-def render_error_response(description: str) -> Response:
-    """Renders an error response in Django."""
-    data = {"error": description}
-    return Response(data, status=status.HTTP_400_BAD_REQUEST)
+def render_error_response(description: str,
+                          status_code: int = status.HTTP_400_BAD_REQUEST,
+                          content_type: str = "application/json") -> Response:
+    """
+    Renders an error response in Django.
+
+    Currently supports HTML or JSON responses.
+    """
+    resp_data = {
+        "data": {"error": description, "status_code": status_code},
+        "status": status_code,
+        "content_type": content_type
+    }
+    if content_type == "text/html":
+        resp_data["template_name"] = "error.html"
+    return Response(**resp_data)
 
 
 def create_transaction_id():

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -116,6 +116,11 @@ STATICFILES_DIRS = (
 # Attributes to add to parent project's REST_FRAMEWORK
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "DEFAULT_RENDERER_CLASSES": [
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+        'rest_framework.renderers.TemplateHTMLRenderer'
+    ],
     "PAGE_SIZE": 10,
 }
 

--- a/polaris/polaris/templates/error.html
+++ b/polaris/polaris/templates/error.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block "title" %}
+<title>Error: {{ status_code }}</title>
+{% endblock %}
+
+{% block "content" %}
+<section class="section">
+    <h2>Error: {{ status_code }}</h2>
+    <p>{{ error }}</p>
+</section>
+{% endblock %}

--- a/polaris/polaris/tests/deposit_test.py
+++ b/polaris/polaris/tests/deposit_test.py
@@ -18,7 +18,7 @@ from polaris.management.commands.create_stellar_deposit import (
     TRUSTLINE_FAILURE_XDR,
 )
 from polaris.models import Transaction
-from polaris.tests.helpers import mock_check_auth_success, mock_render_error_response, mock_load_not_exist_account
+from polaris.tests.helpers import mock_check_auth_success, mock_load_not_exist_account
 
 HORIZON_SUCCESS_RESPONSE = {"result_xdr": SUCCESS_XDR, "hash": "test_stellar_id"}
 
@@ -64,7 +64,10 @@ def test_deposit_no_params(mock_check, client):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "`asset_code` and `account` are required parameters"}
+    assert content == {
+        "error": "`asset_code` and `account` are required parameters",
+        "status_code": 400
+    }
 
 
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
@@ -75,7 +78,10 @@ def test_deposit_no_account(mock_check, client):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "`asset_code` and `account` are required parameters"}
+    assert content == {
+        "error": "`asset_code` and `account` are required parameters",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -88,7 +94,11 @@ def test_deposit_no_asset(mock_check, client, acc1_usd_deposit_transaction_facto
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "`asset_code` and `account` are required parameters"}
+    print(content)
+    assert content == {
+        "error": "`asset_code` and `account` are required parameters",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -106,7 +116,7 @@ def test_deposit_invalid_account(
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "invalid 'account'"}
+    assert content == {"error": "invalid 'account'", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -123,7 +133,7 @@ def test_deposit_invalid_asset(
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "invalid operation for asset GBP"}
+    assert content == {"error": "invalid operation for asset GBP", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -141,7 +151,7 @@ def test_deposit_invalid_memo_type(
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "invalid 'memo_type'"}
+    assert content == {"error": "invalid 'memo_type'", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -157,7 +167,10 @@ def test_deposit_no_memo(mock_check, client, acc1_usd_deposit_transaction_factor
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "'memo_type' provided with no 'memo'"}
+    assert content == {
+        "error": "'memo_type' provided with no 'memo'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -173,7 +186,10 @@ def test_deposit_no_memo_type(mock_check, client, acc1_usd_deposit_transaction_f
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "'memo' provided with no 'memo_type'"}
+    assert content == {
+        "error": "'memo' provided with no 'memo_type'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -191,7 +207,10 @@ def test_deposit_invalid_hash_memo(
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "'memo' does not match memo_type' hash"}
+    assert content == {
+        "error": "'memo' does not match memo_type' hash",
+        "status_code": 400
+    }
 
 
 def test_deposit_confirm_no_txid(client):
@@ -199,7 +218,10 @@ def test_deposit_confirm_no_txid(client):
     response = client.get(f"/deposit/confirm_transaction?amount=0", follow=True)
     content = json.loads(response.content)
     assert response.status_code == 400
-    assert content == {"error": "no 'transaction_id' provided"}
+    assert content == {
+        "error": "no 'transaction_id' provided",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -212,7 +234,10 @@ def test_deposit_confirm_invalid_txid(client):
     )
     content = json.loads(response.content)
     assert response.status_code == 400
-    assert content == {"error": "no transaction with matching 'transaction_id' exists"}
+    assert content == {
+        "error": "no transaction with matching 'transaction_id' exists",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -224,7 +249,7 @@ def test_deposit_confirm_no_amount(client, acc1_usd_deposit_transaction_factory)
     )
     content = json.loads(response.content)
     assert response.status_code == 400
-    assert content == {"error": "no 'amount' provided"}
+    assert content == {"error": "no 'amount' provided", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -237,7 +262,10 @@ def test_deposit_confirm_invalid_amount(client, acc1_usd_deposit_transaction_fac
     )
     content = json.loads(response.content)
     assert response.status_code == 400
-    assert content == {"error": "non-float 'amount' provided"}
+    assert content == {
+        "error": "non-float 'amount' provided",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -252,7 +280,8 @@ def test_deposit_confirm_incorrect_amount(client, acc1_usd_deposit_transaction_f
     content = json.loads(response.content)
     assert response.status_code == 400
     assert content == {
-        "error": "incorrect 'amount' value for transaction with given 'transaction_id'"
+        "error": "incorrect 'amount' value for transaction with given 'transaction_id'",
+        "status_code": 400
     }
 
 
@@ -602,10 +631,8 @@ def test_deposit_authenticated_success(client, acc1_usd_deposit_transaction_fact
 
 
 @pytest.mark.django_db
-@patch("polaris.helpers.render_error_response", side_effect=mock_render_error_response)
-def test_deposit_no_jwt(mock_render, client, acc1_usd_deposit_transaction_factory):
+def test_deposit_no_jwt(client, acc1_usd_deposit_transaction_factory):
     """`GET /deposit` fails if a required JWT isn't provided."""
-    del mock_render
     deposit = acc1_usd_deposit_transaction_factory()
     response = client.get(
         f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=text",
@@ -613,4 +640,5 @@ def test_deposit_no_jwt(mock_render, client, acc1_usd_deposit_transaction_factor
     )
     content = json.loads(response.content)
     assert response.status_code == 400
-    assert content == {"error": "JWT must be passed as 'Authorization' header"}
+    print(content)
+    assert content == {"error": "JWT must be passed as 'Authorization' header", "status_code": 400}

--- a/polaris/polaris/tests/fee_test.py
+++ b/polaris/polaris/tests/fee_test.py
@@ -7,7 +7,7 @@ from stellar_sdk.keypair import Keypair
 from stellar_sdk.transaction_envelope import TransactionEnvelope
 
 from polaris import settings
-from polaris.tests.helpers import mock_check_auth_success, mock_render_error_response
+from polaris.tests.helpers import mock_check_auth_success
 
 
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
@@ -18,7 +18,7 @@ def test_fee_no_params(mock_check, client):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "invalid 'asset_code'"}
+    assert content == {"error": "invalid 'asset_code'", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -30,7 +30,7 @@ def test_fee_wrong_asset_code(mock_check, client):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "invalid 'asset_code'"}
+    assert content == {"error": "invalid 'asset_code'", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -43,7 +43,10 @@ def test_fee_no_operation(mock_check, client, usd_asset_factory):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "'operation' should be either 'deposit' or 'withdraw'"}
+    assert content == {
+        "error": "'operation' should be either 'deposit' or 'withdraw'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -56,7 +59,10 @@ def test_fee_invalid_operation(mock_check, client, usd_asset_factory):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "'operation' should be either 'deposit' or 'withdraw'"}
+    assert content == {
+        "error": "'operation' should be either 'deposit' or 'withdraw'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -69,7 +75,10 @@ def test_fee_no_amount(mock_check, client, usd_asset_factory):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "invalid 'amount'"}
+    assert content == {
+        "error": "invalid 'amount'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -84,7 +93,7 @@ def test_fee_invalid_amount(mock_check, client, usd_asset_factory):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "invalid 'amount'"}
+    assert content == {"error": "invalid 'amount'", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -99,7 +108,10 @@ def test_fee_invalid_operation_type_deposit(mock_check, client, usd_asset_factor
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "the specified operation is not available for 'USD'"}
+    assert content == {
+        "error": "the specified operation is not available for 'USD'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -114,7 +126,10 @@ def test_fee_invalid_operation_type_withdraw(mock_check, client, usd_asset_facto
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "the specified operation is not available for 'USD'"}
+    assert content == {
+        "error": "the specified operation is not available for 'USD'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -130,7 +145,10 @@ def test_fee_withdraw_disabled(mock_check, client, eth_asset_factory):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "the specified operation is not available for 'ETH'"}
+    assert content == {
+        "error": "the specified operation is not available for 'ETH'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -148,7 +166,10 @@ def test_fee_deposit_disabled(mock_check, client, eth_asset_factory):
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "the specified operation is not available for 'ETH'"}
+    assert content == {
+        "error": "the specified operation is not available for 'ETH'",
+        "status_code": 400
+    }
 
 
 @pytest.mark.django_db
@@ -185,10 +206,8 @@ def test_fee_valid_withdrawal(mock_check, client, usd_asset_factory):
 
 
 @pytest.mark.django_db
-@patch("polaris.helpers.render_error_response", side_effect=mock_render_error_response)
-def test_fee_authenticated_success(mock_render, client, usd_asset_factory):
+def test_fee_authenticated_success(client, usd_asset_factory):
     """Succeeds for a valid fee, with successful authentication."""
-    del mock_render
     usd_asset_factory()
     client_address = "GDKFNRUATPH4BSZGVFDRBIGZ5QAFILVFRIRYNSQ4UO7V2ZQAPRNL73RI"
     client_seed = "SDKWSBERDHP3SXW5A3LXSI7FWMMO5H7HG33KNYBKWH2HYOXJG2DXQHQY"
@@ -225,14 +244,15 @@ def test_fee_authenticated_success(mock_render, client, usd_asset_factory):
 
 
 @pytest.mark.django_db
-@patch("polaris.helpers.render_error_response", side_effect=mock_render_error_response)
-def test_fee_no_jwt(mock_render, client, usd_asset_factory):
+def test_fee_no_jwt(client, usd_asset_factory):
     """`GET /fee` fails if a required JWT is not provided."""
-    del mock_render
     usd_asset_factory()
     response = client.get(
         f"/fee?asset_code=USD&operation=withdraw&amount=100.0", follow=True
     )
     content = json.loads(response.content)
     assert response.status_code == 400
-    assert content == {"error": "JWT must be passed as 'Authorization' header"}
+    assert content == {
+        "error": "JWT must be passed as 'Authorization' header",
+        "status_code": 400
+    }

--- a/polaris/polaris/tests/helpers.py
+++ b/polaris/polaris/tests/helpers.py
@@ -13,11 +13,6 @@ def mock_check_auth_success(request, func):
     return func(request)
 
 
-def mock_render_error_response(error_str):
-    """Mocks `helpers.render_error_response`, for failure."""
-    return JsonResponse({"error": error_str}, status=400)
-
-
 def mock_load_not_exist_account(account_id):
     if account_id != settings.STELLAR_ISSUER_ACCOUNT_ADDRESS and account_id != settings.STELLAR_DISTRIBUTION_ACCOUNT_ADDRESS:
         raise NotFoundError(response=Response(status_code=404, headers={}, url="", text=json.dumps(dict(status=404))))

--- a/polaris/polaris/tests/settings.py
+++ b/polaris/polaris/tests/settings.py
@@ -1,0 +1,5 @@
+"""Override polaris.settings for testing purposes"""
+
+from polaris.settings import *
+
+del STATICFILES_STORAGE

--- a/polaris/polaris/tests/transaction_test.py
+++ b/polaris/polaris/tests/transaction_test.py
@@ -8,7 +8,7 @@ from stellar_sdk.transaction_envelope import TransactionEnvelope
 
 from polaris import settings
 from polaris.models import Transaction
-from polaris.tests.helpers import mock_check_auth_success, mock_render_error_response
+from polaris.tests.helpers import mock_check_auth_success
 
 
 @pytest.mark.django_db
@@ -202,9 +202,7 @@ def test_transaction_filtering_no_result(
 
 
 @pytest.mark.django_db
-@patch("polaris.helpers.render_error_response", side_effect=mock_render_error_response)
 def test_transaction_authenticated_success(
-    mock_render,
     client,
     acc1_usd_deposit_transaction_factory,
     acc2_eth_withdrawal_transaction_factory,
@@ -214,7 +212,6 @@ def test_transaction_authenticated_success(
     Though it filters using the stellar transaction ID, the logic
     should apply in any case.
     """
-    del mock_render
     client_address = "GDKFNRUATPH4BSZGVFDRBIGZ5QAFILVFRIRYNSQ4UO7V2ZQAPRNL73RI"
     client_seed = "SDKWSBERDHP3SXW5A3LXSI7FWMMO5H7HG33KNYBKWH2HYOXJG2DXQHQY"
     acc1_usd_deposit_transaction_factory()
@@ -258,12 +255,10 @@ def test_transaction_authenticated_success(
 
 
 @pytest.mark.django_db
-@patch("polaris.helpers.render_error_response", side_effect=mock_render_error_response)
 def test_transaction_no_jwt(
-    mock_render, client, acc2_eth_withdrawal_transaction_factory
+    client, acc2_eth_withdrawal_transaction_factory
 ):
     """Fails if required JWT is not provided."""
-    del mock_render
     withdrawal = acc2_eth_withdrawal_transaction_factory()
 
     response = client.get(
@@ -277,4 +272,4 @@ def test_transaction_no_jwt(
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {"error": "JWT must be passed as 'Authorization' header"}
+    assert content == {"error": "JWT must be passed as 'Authorization' header", "status_code": 400}

--- a/polaris/polaris/tests/transactions_more_info_test.py
+++ b/polaris/polaris/tests/transactions_more_info_test.py
@@ -8,9 +8,7 @@ def test_more_info_required_fields(client, acc1_usd_deposit_transaction_factory)
     """Fails if no required fields are provided."""
     acc1_usd_deposit_transaction_factory()
     response = client.get(f"/transaction/more_info", follow=True)
-    content = json.loads(response.content)
     assert response.status_code == 400
-    assert content.get("error")
 
 
 @pytest.mark.django_db
@@ -72,7 +70,5 @@ def test_more_info_no_result(
         f"/transaction/more_info?id={deposit.id}&external_transaction_id={withdrawal.external_transaction_id}&stellar_transaction_id={withdrawal.stellar_transaction_id}",
         follow=True,
     )
-    content = json.loads(response.content)
     assert response.status_code == 404
-    assert content.get("error")
 

--- a/polaris/polaris/tests/transactions_test.py
+++ b/polaris/polaris/tests/transactions_test.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from stellar_sdk.keypair import Keypair
 from stellar_sdk.transaction_envelope import TransactionEnvelope
 
-from polaris.tests.helpers import mock_check_auth_success, mock_render_error_response
+from polaris.tests.helpers import mock_check_auth_success
 
 
 @pytest.mark.django_db
@@ -405,9 +405,7 @@ def test_no_older_than_filter(
 
 
 @pytest.mark.django_db
-@patch("polaris.helpers.render_error_response", side_effect=mock_render_error_response)
 def test_transactions_authenticated_success(
-    mock_render,
     client,
     acc2_eth_withdrawal_transaction_factory,
     acc2_eth_deposit_transaction_factory,
@@ -416,7 +414,6 @@ def test_transactions_authenticated_success(
     Response has correct length and status code, if the SEP 10 authentication
     token is required.
     """
-    del mock_render
     client_address = "GDKFNRUATPH4BSZGVFDRBIGZ5QAFILVFRIRYNSQ4UO7V2ZQAPRNL73RI"
     client_seed = "SDKWSBERDHP3SXW5A3LXSI7FWMMO5H7HG33KNYBKWH2HYOXJG2DXQHQY"
     withdrawal = acc2_eth_withdrawal_transaction_factory()
@@ -458,12 +455,10 @@ def test_transactions_authenticated_success(
 
 
 @pytest.mark.django_db
-@patch("polaris.helpers.render_error_response", side_effect=mock_render_error_response)
 def test_transactions_no_jwt(
-    mock_render, client, acc2_eth_withdrawal_transaction_factory
+    client, acc2_eth_withdrawal_transaction_factory
 ):
     """`GET /transactions` fails if a required JWT is not provided."""
-    del mock_render
     withdrawal = acc2_eth_withdrawal_transaction_factory()
     response = client.get(
         f"/transactions?asset_code={withdrawal.asset.code}&account={withdrawal.stellar_account}",
@@ -471,4 +466,4 @@ def test_transactions_no_jwt(
     )
     content = json.loads(response.content)
     assert response.status_code == 400
-    assert content == {"error": "JWT must be passed as 'Authorization' header"}
+    assert content == {"error": "JWT must be passed as 'Authorization' header", "status_code": 400}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = polaris.settings
+DJANGO_SETTINGS_MODULE = polaris.tests.settings
 python_files = test.py test_*.py *_test.py
 addopts = --rootdir polaris/

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="django-polaris",
-    version=0.9,
+    version="0.9.1",
     description="A SEP-24-compliant Django anchor server",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Reason:
I discovered django rendering issues from hitting Polaris endpoints while testing from stellar-anchor-server.

Problem:
For our `/interactive_deposit`, `/interactive_withdraw`, and `/more_info` endpoints, we were returning an HTML form for a successful request and JSON for a failed request. This was causing django to fail while attempting to render the response.

It turns out that Django Rest Framework doesn't play nicely with returning different content types from the same endpoint, see [the docs](https://www.django-rest-framework.org/api-guide/renderers/). Essentially, the caller of the endpoint must specify the content type they're expecting, otherwise Django Rest Framework expects our endpoints to return the default content type for the function.

Solution:
I converted each of these endpoints to only return HTML, even on failure. From the caller's perspective, it would have been confusing to expect HTML and receive JSON anyway. The HTML rendered on failure is a new and simple `error.html` template that displays the error message and status code.

Extas:
I also added a `settings.py` file explicitly for testing, since some settings needed to be changed to run locally.
 