### PR TITLE
Convert to new POST endpoints

### DIFF
--- a/polaris/polaris/deposit/urls.py
+++ b/polaris/polaris/deposit/urls.py
@@ -1,9 +1,10 @@
 """This module defines the URL patterns for the `/deposit` endpoint."""
 from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
 from polaris.deposit.views import deposit, interactive_deposit, confirm_transaction
 
 urlpatterns = [
-    path("", deposit),
-    path("/interactive_deposit", interactive_deposit, name="interactive_deposit"),
-    path("/confirm_transaction", confirm_transaction, name="confirm_transaction"),
+    path("transactions/deposit/interactive", csrf_exempt(deposit)),
+    path("deposit/interactive_deposit", interactive_deposit, name="interactive_deposit"),
+    path("deposit/confirm_transaction", confirm_transaction, name="confirm_transaction"),
 ]

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -205,7 +205,8 @@ def interactive_deposit(request):
     return Response({"form": form}, template_name="deposit/form.html")
 
 
-@api_view()
+@api_view(["POST"])
+@renderer_classes([JSONRenderer])
 @validate_sep10_token()
 def deposit(request):
     """

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -11,6 +11,7 @@ import json
 from urllib.parse import urlencode
 
 from polaris import settings
+from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -18,7 +19,7 @@ from django.core.management import call_command
 from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
-from rest_framework.renderers import TemplateHTMLRenderer
+from rest_framework.renderers import TemplateHTMLRenderer, JSONRenderer
 from stellar_sdk.keypair import Keypair
 from stellar_sdk.exceptions import Ed25519PublicKeyInvalidError
 
@@ -35,13 +36,13 @@ from polaris.transaction.serializers import TransactionSerializer
 from polaris.deposit.forms import DepositForm
 
 
-def _construct_interactive_url(request, transaction_id):
+def _construct_interactive_url(request, asset_code, account, transaction_id): 
     """Constructs the URL for the deposit application for deposit info.
     This is located at `/deposit/interactive_deposit`."""
     qparams = urlencode(
         {
-            "asset_code": request.GET.get("asset_code"),
-            "account": request.GET.get("account"),
+            "asset_code": asset_code,
+            "account": account,
             "transaction_id": transaction_id,
         }
     )
@@ -64,11 +65,11 @@ def _construct_more_info_url(request):
 # pass these to the pop-up.
 def _verify_optional_args(request):
     """Verify the optional arguments to `GET /deposit`."""
-    memo_type = request.GET.get("memo_type")
+    memo_type = request.POST.get("memo_type")
     if memo_type and memo_type not in ("text", "id", "hash"):
         return render_error_response("invalid 'memo_type'")
 
-    memo = request.GET.get("memo")
+    memo = request.POST.get("memo")
     if memo_type and not memo:
         return render_error_response("'memo_type' provided with no 'memo'")
 
@@ -208,11 +209,11 @@ def interactive_deposit(request):
 @validate_sep10_token()
 def deposit(request):
     """
-    `GET /deposit` initiates the deposit and returns an interactive
+    `POST /transactions/deposit/interactive` initiates the deposit and returns an interactive
     deposit form to the user.
     """
-    asset_code = request.GET.get("asset_code")
-    stellar_account = request.GET.get("account")
+    asset_code = request.POST.get("asset_code")
+    stellar_account = request.POST.get("account")
 
     # Verify that the request is valid.
     if not all([asset_code, stellar_account]):
@@ -237,7 +238,7 @@ def deposit(request):
 
     # Construct interactive deposit pop-up URL.
     transaction_id = create_transaction_id()
-    url = _construct_interactive_url(request, transaction_id)
+    url = _construct_interactive_url(request, asset_code, stellar_account, transaction_id)
     return Response(
         {"type": "interactive_customer_info_needed", "url": url, "id": transaction_id},
         status=status.HTTP_403_FORBIDDEN,

--- a/polaris/polaris/tests/deposit_test.py
+++ b/polaris/polaris/tests/deposit_test.py
@@ -20,85 +20,73 @@ from polaris.management.commands.create_stellar_deposit import (
 from polaris.models import Transaction
 from polaris.tests.helpers import mock_check_auth_success, mock_load_not_exist_account
 
+DEPOSIT_PATH = f"/transactions/deposit/interactive"
 HORIZON_SUCCESS_RESPONSE = {"result_xdr": SUCCESS_XDR, "hash": "test_stellar_id"}
-
 
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_success(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` succeeds with no optional arguments."""
+    """`POST /transactions/deposit/interactive` succeeds with no optional arguments."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
     )
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_success_memo(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` succeeds with valid `memo` and `memo_type`."""
+    """`POST /transactions/deposit/interactive` succeeds with valid `memo` and `memo_type`."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text", "memo": "foo"},
         follow=True,
     )
 
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_params(mock_check, client):
-    """`GET /deposit` fails with no required parameters."""
+    """`POST /transactions/deposit/interactive` fails with no required parameters."""
     # Because this test does not use the database, the changed setting
     # earlier in the file is not persisted when the tests not requiring
     # a database are run. Thus, we set that flag again here.
     del mock_check
-    response = client.get(f"/deposit", follow=True)
+    response = client.post(
+        DEPOSIT_PATH, {}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {
-        "error": "`asset_code` and `account` are required parameters",
-        "status_code": 400
-    }
-
+    assert content == {"error": "`asset_code` and `account` are required parameters", "status_code": 400}
 
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_account(mock_check, client):
-    """`GET /deposit` fails with no `account` parameter."""
+    """`POST /transactions/deposit/interactive` fails with no `account` parameter."""
     del mock_check
-    response = client.get(f"/deposit?asset_code=NADA", follow=True)
+    response = client.post(DEPOSIT_PATH, {"asset_code": "NADA"}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {
-        "error": "`asset_code` and `account` are required parameters",
-        "status_code": 400
-    }
+    assert content == {"error": "`asset_code` and `account` are required parameters", "status_code": 400}
 
 
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_asset(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with no `asset_code` parameter."""
+    """`POST /transactions/deposit/interactive` fails with no `asset_code` parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(f"/deposit?account={deposit.stellar_account}", follow=True)
+    response = client.post(DEPOSIT_PATH, {"account": deposit.stellar_account}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    print(content)
-    assert content == {
-        "error": "`asset_code` and `account` are required parameters",
-        "status_code": 400
-    }
+    assert content == {"error": "`asset_code` and `account` are required parameters", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -106,11 +94,11 @@ def test_deposit_no_asset(mock_check, client, acc1_usd_deposit_transaction_facto
 def test_deposit_invalid_account(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `account` parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `account` parameter."""
     del mock_check
     acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account=GBSH7WNSDU5FEIED2JQZIOQPZXREO3YNH2M5DIBE8L2X5OOAGZ7N2QI6",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": "GBSH7WNSDU5FEIED2JQZIOQPZXREO3YNH2M5DIBE8L2X5OOAGZ7N2QI6"},
         follow=True,
     )
     content = json.loads(response.content)
@@ -124,11 +112,11 @@ def test_deposit_invalid_account(
 def test_deposit_invalid_asset(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `asset_code` parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `asset_code` parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=GBP&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "GBP", "account": deposit.stellar_account}, follow=True
     )
     content = json.loads(response.content)
 
@@ -141,11 +129,11 @@ def test_deposit_invalid_asset(
 def test_deposit_invalid_memo_type(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `memo_type` optional parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `memo_type` optional parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo_type=test",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "test"},
         follow=True,
     )
     content = json.loads(response.content)
@@ -157,39 +145,33 @@ def test_deposit_invalid_memo_type(
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_memo(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with a valid `memo_type` and no `memo` provided."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo_type` and no `memo` provided."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text"},
         follow=True,
     )
     content = json.loads(response.content)
-
+    print(response)
     assert response.status_code == 400
-    assert content == {
-        "error": "'memo_type' provided with no 'memo'",
-        "status_code": 400
-    }
+    assert content == {"error": "'memo_type' provided with no 'memo'", "status_code": 400}
 
 
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_memo_type(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with a valid `memo` and no `memo_type` provided."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo` and no `memo_type` provided."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo": "text"},
         follow=True,
     )
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {
-        "error": "'memo' provided with no 'memo_type'",
-        "status_code": 400
-    }
+    assert content == {"error": "'memo' provided with no 'memo_type'", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -197,20 +179,17 @@ def test_deposit_no_memo_type(mock_check, client, acc1_usd_deposit_transaction_f
 def test_deposit_invalid_hash_memo(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with a valid `memo` of incorrect `memo_type` hash."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo` of incorrect `memo_type` hash."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=hash",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "hash", "memo": "foo"},
         follow=True,
     )
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {
-        "error": "'memo' does not match memo_type' hash",
-        "status_code": 400
-    }
+    assert content == {"error": "'memo' does not match memo_type' hash", "status_code": 400}
 
 
 def test_deposit_confirm_no_txid(client):
@@ -438,8 +417,9 @@ def test_deposit_interactive_confirm_success(
     """
     del mock_check, mock_submit, mock_base_fee
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
+        follow=True
     )
     content = json.loads(response.content)
     assert response.status_code == 403
@@ -620,8 +600,8 @@ def test_deposit_authenticated_success(client, acc1_usd_deposit_transaction_fact
     assert encoded_jwt
 
     header = {"HTTP_AUTHORIZATION": f"Bearer {encoded_jwt}"}
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
         follow=True,
         **header,
     )
@@ -634,8 +614,8 @@ def test_deposit_authenticated_success(client, acc1_usd_deposit_transaction_fact
 def test_deposit_no_jwt(client, acc1_usd_deposit_transaction_factory):
     """`GET /deposit` fails if a required JWT isn't provided."""
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text", "memo": "foo"},
         follow=True,
     )
     content = json.loads(response.content)

--- a/polaris/polaris/urls.py
+++ b/polaris/polaris/urls.py
@@ -17,11 +17,11 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
+    path(".well-known", include("polaris.stellartoml.urls")),
     path("info", include("polaris.info.urls")),
     path("fee", include("polaris.fee.urls")),
     path("", include("polaris.transaction.urls")),
-    path("deposit", include("polaris.deposit.urls")),
-    path(".well-known", include("polaris.stellartoml.urls")),
-    path("withdraw", include("polaris.withdraw.urls")),
+    path("", include("polaris.deposit.urls")),
+    path("", include("polaris.withdraw.urls")),
     path("auth", include("polaris.sep10auth.urls")),
 ]

--- a/polaris/polaris/withdraw/urls.py
+++ b/polaris/polaris/withdraw/urls.py
@@ -1,8 +1,9 @@
 """This module defines the URL patterns for the `/withdraw` endpoint."""
 from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
 from polaris.withdraw.views import withdraw, interactive_withdraw
 
 urlpatterns = [
-    path("", withdraw),
-    path("/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
+    path("transactions/withdraw/interactive", csrf_exempt(withdraw)),
+    path("withdraw/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
 ]

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -13,7 +13,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
-from rest_framework.renderers import TemplateHTMLRenderer
+from rest_framework.renderers import TemplateHTMLRenderer, JSONRenderer
 
 from polaris.helpers import (
     render_error_response,
@@ -26,11 +26,11 @@ from polaris.transaction.serializers import TransactionSerializer
 from polaris.withdraw.forms import WithdrawForm
 
 
-def _construct_interactive_url(request, transaction_id):
+def _construct_interactive_url(request, asset_code, transaction_id):
     """Constructs the URL for the interactive application for withdrawal info.
     This is located at `/withdraw/interactive_withdraw`."""
     qparams = urlencode(
-        {"asset_code": request.GET.get("asset_code"), "transaction_id": transaction_id}
+        {"asset_code": asset_code, "transaction_id": transaction_id}
     )
     path = reverse("interactive_withdraw")
     url_params = f"{path}?{qparams}"
@@ -121,14 +121,15 @@ def interactive_withdraw(request):
     return Response({"form": form}, template_name="withdraw/form.html")
 
 
-@api_view()
+@api_view(["POST"])
 @validate_sep10_token()
+@renderer_classes([JSONRenderer])
 def withdraw(request):
     """
     `GET /withdraw` initiates the withdrawal and returns an interactive
     withdrawal form to the user.
     """
-    asset_code = request.GET.get("asset_code")
+    asset_code = request.POST.get("asset_code")
     if not asset_code:
         return render_error_response("'asset_code' is required")
 
@@ -140,7 +141,7 @@ def withdraw(request):
         return render_error_response(f"invalid operation for asset {asset_code}")
 
     transaction_id = create_transaction_id()
-    url = _construct_interactive_url(request, transaction_id)
+    url = _construct_interactive_url(request, asset_code, transaction_id)
     return Response(
         {"type": "interactive_customer_info_needed", "url": url, "id": transaction_id},
         status=status.HTTP_403_FORBIDDEN,

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -126,7 +126,7 @@ def interactive_withdraw(request):
 @renderer_classes([JSONRenderer])
 def withdraw(request):
     """
-    `GET /withdraw` initiates the withdrawal and returns an interactive
+    `POST /withdraw` initiates the withdrawal and returns an interactive
     withdrawal form to the user.
     """
     asset_code = request.POST.get("asset_code")
@@ -144,5 +144,4 @@ def withdraw(request):
     url = _construct_interactive_url(request, asset_code, transaction_id)
     return Response(
         {"type": "interactive_customer_info_needed", "url": url, "id": transaction_id},
-        status=status.HTTP_403_FORBIDDEN,
     )


### PR DESCRIPTION
In stellar/stellar-protocol#438 we change the /deposit and /withdraw endpoints to new URLs and change them to POST instead of GET for security. This makes the changes specified in that PR.

Changes /deposit to /transactions/deposit/interactive
Changes /withdraw to /transactions/withdraw/interactive
Changes both endpoints to POST

Land with stellar/sep24-demo-client#133