### PR TITLE
0.9.2.dev to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,10 @@ At the time of writing this, the latest public release is v0.9.
 After each release, a new development branch is created for the next upcoming release. In this case, that is 0.9.1.dev.
 Follow the instructions below to submit a valid pull request.
 
-1. Checkout the current development branch (0.9.1.dev) (`git checkout`)
-1. Create a new branch based off the latest dev branch (`git checkout -b`)
-1. Make your changes (`git add .; git commit -m`)
-1. Push your changes to a new remote branch matching your local branch (`git push --set-upstream origin`)
-1. Create a pull request based off the current dev branch
-    1. If the latest dev branch has changed, rebase your branch on the new dev branch (`git fetch; git rebase`)
-
+1. Fork the repository
+1. Make your changes
+1. Push your changes to your forked repository
+1. Create a pull request based off master
 
 ### Testing
 ```.env

--- a/polaris/polaris/deposit/urls.py
+++ b/polaris/polaris/deposit/urls.py
@@ -1,9 +1,10 @@
 """This module defines the URL patterns for the `/deposit` endpoint."""
 from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
 from polaris.deposit.views import deposit, interactive_deposit, confirm_transaction
 
 urlpatterns = [
-    path("", deposit),
-    path("/interactive_deposit", interactive_deposit, name="interactive_deposit"),
-    path("/confirm_transaction", confirm_transaction, name="confirm_transaction"),
+    path("transactions/deposit/interactive", csrf_exempt(deposit)),
+    path("deposit/interactive_deposit", interactive_deposit, name="interactive_deposit"),
+    path("deposit/confirm_transaction", confirm_transaction, name="confirm_transaction"),
 ]

--- a/polaris/polaris/deposit/urls.py
+++ b/polaris/polaris/deposit/urls.py
@@ -5,6 +5,6 @@ from polaris.deposit.views import deposit, interactive_deposit, confirm_transact
 
 urlpatterns = [
     path("transactions/deposit/interactive", csrf_exempt(deposit)),
-    path("deposit/interactive_deposit", interactive_deposit, name="interactive_deposit"),
-    path("deposit/confirm_transaction", confirm_transaction, name="confirm_transaction"),
+    path("transactions/deposit/webapp", interactive_deposit, name="interactive_deposit"),
+    path("transactions/deposit/confirm_transaction", confirm_transaction, name="confirm_transaction"),
 ]

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -11,6 +11,7 @@ import json
 from urllib.parse import urlencode
 
 from polaris import settings
+from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -18,7 +19,7 @@ from django.core.management import call_command
 from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
-from rest_framework.renderers import TemplateHTMLRenderer
+from rest_framework.renderers import TemplateHTMLRenderer, JSONRenderer
 from stellar_sdk.keypair import Keypair
 from stellar_sdk.exceptions import Ed25519PublicKeyInvalidError
 
@@ -35,13 +36,13 @@ from polaris.transaction.serializers import TransactionSerializer
 from polaris.deposit.forms import DepositForm
 
 
-def _construct_interactive_url(request, transaction_id):
+def _construct_interactive_url(request, asset_code, account, transaction_id): 
     """Constructs the URL for the deposit application for deposit info.
     This is located at `/deposit/interactive_deposit`."""
     qparams = urlencode(
         {
-            "asset_code": request.GET.get("asset_code"),
-            "account": request.GET.get("account"),
+            "asset_code": asset_code,
+            "account": account,
             "transaction_id": transaction_id,
         }
     )
@@ -64,11 +65,11 @@ def _construct_more_info_url(request):
 # pass these to the pop-up.
 def _verify_optional_args(request):
     """Verify the optional arguments to `GET /deposit`."""
-    memo_type = request.GET.get("memo_type")
+    memo_type = request.POST.get("memo_type")
     if memo_type and memo_type not in ("text", "id", "hash"):
         return render_error_response("invalid 'memo_type'")
 
-    memo = request.GET.get("memo")
+    memo = request.POST.get("memo")
     if memo_type and not memo:
         return render_error_response("'memo_type' provided with no 'memo'")
 
@@ -204,15 +205,16 @@ def interactive_deposit(request):
     return Response({"form": form}, template_name="deposit/form.html")
 
 
-@api_view()
+@api_view(["POST"])
+@renderer_classes([JSONRenderer])
 @validate_sep10_token()
 def deposit(request):
     """
-    `GET /deposit` initiates the deposit and returns an interactive
+    `POST /transactions/deposit/interactive` initiates the deposit and returns an interactive
     deposit form to the user.
     """
-    asset_code = request.GET.get("asset_code")
-    stellar_account = request.GET.get("account")
+    asset_code = request.POST.get("asset_code")
+    stellar_account = request.POST.get("account")
 
     # Verify that the request is valid.
     if not all([asset_code, stellar_account]):
@@ -237,7 +239,7 @@ def deposit(request):
 
     # Construct interactive deposit pop-up URL.
     transaction_id = create_transaction_id()
-    url = _construct_interactive_url(request, transaction_id)
+    url = _construct_interactive_url(request, asset_code, stellar_account, transaction_id)
     return Response(
         {"type": "interactive_customer_info_needed", "url": url, "id": transaction_id},
         status=status.HTTP_403_FORBIDDEN,

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -38,7 +38,7 @@ from polaris.deposit.forms import DepositForm
 
 def _construct_interactive_url(request, asset_code, account, transaction_id): 
     """Constructs the URL for the deposit application for deposit info.
-    This is located at `/deposit/interactive_deposit`."""
+    This is located at `/transactions/deposit/webapp`."""
     qparams = urlencode(
         {
             "asset_code": asset_code,
@@ -87,7 +87,7 @@ def _verify_optional_args(request):
 @api_view()
 def confirm_transaction(request):
     """
-    `GET /deposit/confirm_transaction` is used by an external agent to confirm
+    `GET /transactions/deposit/confirm_transaction` is used by an external agent to confirm
     that they have processed the transaction. This triggers submission of the
     corresponding Stellar transaction.
 
@@ -142,7 +142,7 @@ def confirm_transaction(request):
 @renderer_classes([TemplateHTMLRenderer])
 def interactive_deposit(request):
     """
-    `GET /deposit/interactive_deposit` opens a form used to input information
+    `GET /transactions/deposit/webapp` opens a form used to input information
     about the deposit. This creates a corresponding transaction in our
     database, pending processing by the external agent.
     """

--- a/polaris/polaris/management/commands/create_stellar_deposit.py
+++ b/polaris/polaris/management/commands/create_stellar_deposit.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
 
         # We check the Transaction status to avoid double submission of a Stellar
         # transaction. The Transaction can be either `pending_anchor` if the task
-        # is called from `GET deposit/confirm_transaction` or `pending_trust` if called
+        # is called from `GET transactions/deposit/confirm_transaction` or `pending_trust` if called
         # from the `check_trustlines()`.
         if transaction.status not in [
             Transaction.STATUS.pending_anchor,

--- a/polaris/polaris/templates/transaction/more_info.html
+++ b/polaris/polaris/templates/transaction/more_info.html
@@ -101,7 +101,7 @@
             transactionId = transaction["id"];
             amount = transaction["amount_in"];
             xhr = new XMLHttpRequest();
-            xhrUrl = '/deposit/confirm_transaction?transaction_id=' + transactionId + '&amount=' + amount;
+            xhrUrl = '/transactions/deposit/confirm_transaction?transaction_id=' + transactionId + '&amount=' + amount;
             xhr.open('get', xhrUrl, true);
             xhr.onload = function () {
                 if (this.status >= 200 && this.status < 400) {

--- a/polaris/polaris/tests/deposit_test.py
+++ b/polaris/polaris/tests/deposit_test.py
@@ -20,85 +20,73 @@ from polaris.management.commands.create_stellar_deposit import (
 from polaris.models import Transaction
 from polaris.tests.helpers import mock_check_auth_success, mock_load_not_exist_account
 
+DEPOSIT_PATH = f"/transactions/deposit/interactive"
 HORIZON_SUCCESS_RESPONSE = {"result_xdr": SUCCESS_XDR, "hash": "test_stellar_id"}
-
 
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_success(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` succeeds with no optional arguments."""
+    """`POST /transactions/deposit/interactive` succeeds with no optional arguments."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
     )
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_success_memo(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` succeeds with valid `memo` and `memo_type`."""
+    """`POST /transactions/deposit/interactive` succeeds with valid `memo` and `memo_type`."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text", "memo": "foo"},
         follow=True,
     )
 
     content = json.loads(response.content)
-    assert response.status_code == 403
     assert content["type"] == "interactive_customer_info_needed"
 
 
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_params(mock_check, client):
-    """`GET /deposit` fails with no required parameters."""
+    """`POST /transactions/deposit/interactive` fails with no required parameters."""
     # Because this test does not use the database, the changed setting
     # earlier in the file is not persisted when the tests not requiring
     # a database are run. Thus, we set that flag again here.
     del mock_check
-    response = client.get(f"/deposit", follow=True)
+    response = client.post(
+        DEPOSIT_PATH, {}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {
-        "error": "`asset_code` and `account` are required parameters",
-        "status_code": 400
-    }
-
+    assert content == {"error": "`asset_code` and `account` are required parameters", "status_code": 400}
 
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_account(mock_check, client):
-    """`GET /deposit` fails with no `account` parameter."""
+    """`POST /transactions/deposit/interactive` fails with no `account` parameter."""
     del mock_check
-    response = client.get(f"/deposit?asset_code=NADA", follow=True)
+    response = client.post(DEPOSIT_PATH, {"asset_code": "NADA"}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {
-        "error": "`asset_code` and `account` are required parameters",
-        "status_code": 400
-    }
+    assert content == {"error": "`asset_code` and `account` are required parameters", "status_code": 400}
 
 
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_asset(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with no `asset_code` parameter."""
+    """`POST /transactions/deposit/interactive` fails with no `asset_code` parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(f"/deposit?account={deposit.stellar_account}", follow=True)
+    response = client.post(DEPOSIT_PATH, {"account": deposit.stellar_account}, follow=True)
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    print(content)
-    assert content == {
-        "error": "`asset_code` and `account` are required parameters",
-        "status_code": 400
-    }
+    assert content == {"error": "`asset_code` and `account` are required parameters", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -106,11 +94,11 @@ def test_deposit_no_asset(mock_check, client, acc1_usd_deposit_transaction_facto
 def test_deposit_invalid_account(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `account` parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `account` parameter."""
     del mock_check
     acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account=GBSH7WNSDU5FEIED2JQZIOQPZXREO3YNH2M5DIBE8L2X5OOAGZ7N2QI6",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": "GBSH7WNSDU5FEIED2JQZIOQPZXREO3YNH2M5DIBE8L2X5OOAGZ7N2QI6"},
         follow=True,
     )
     content = json.loads(response.content)
@@ -124,11 +112,11 @@ def test_deposit_invalid_account(
 def test_deposit_invalid_asset(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `asset_code` parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `asset_code` parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=GBP&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "GBP", "account": deposit.stellar_account}, follow=True
     )
     content = json.loads(response.content)
 
@@ -141,11 +129,11 @@ def test_deposit_invalid_asset(
 def test_deposit_invalid_memo_type(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with an invalid `memo_type` optional parameter."""
+    """`POST /transactions/deposit/interactive` fails with an invalid `memo_type` optional parameter."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo_type=test",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "test"},
         follow=True,
     )
     content = json.loads(response.content)
@@ -157,39 +145,33 @@ def test_deposit_invalid_memo_type(
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_memo(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with a valid `memo_type` and no `memo` provided."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo_type` and no `memo` provided."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text"},
         follow=True,
     )
     content = json.loads(response.content)
-
+    print(response)
     assert response.status_code == 400
-    assert content == {
-        "error": "'memo_type' provided with no 'memo'",
-        "status_code": 400
-    }
+    assert content == {"error": "'memo_type' provided with no 'memo'", "status_code": 400}
 
 
 @pytest.mark.django_db
 @patch("polaris.helpers.check_auth", side_effect=mock_check_auth_success)
 def test_deposit_no_memo_type(mock_check, client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit` fails with a valid `memo` and no `memo_type` provided."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo` and no `memo_type` provided."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo": "text"},
         follow=True,
     )
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {
-        "error": "'memo' provided with no 'memo_type'",
-        "status_code": 400
-    }
+    assert content == {"error": "'memo' provided with no 'memo_type'", "status_code": 400}
 
 
 @pytest.mark.django_db
@@ -197,20 +179,17 @@ def test_deposit_no_memo_type(mock_check, client, acc1_usd_deposit_transaction_f
 def test_deposit_invalid_hash_memo(
     mock_check, client, acc1_usd_deposit_transaction_factory
 ):
-    """`GET /deposit` fails with a valid `memo` of incorrect `memo_type` hash."""
+    """`POST /transactions/deposit/interactive` fails with a valid `memo` of incorrect `memo_type` hash."""
     del mock_check
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=hash",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "hash", "memo": "foo"},
         follow=True,
     )
     content = json.loads(response.content)
 
     assert response.status_code == 400
-    assert content == {
-        "error": "'memo' does not match memo_type' hash",
-        "status_code": 400
-    }
+    assert content == {"error": "'memo' does not match memo_type' hash", "status_code": 400}
 
 
 def test_deposit_confirm_no_txid(client):
@@ -438,8 +417,9 @@ def test_deposit_interactive_confirm_success(
     """
     del mock_check, mock_submit, mock_base_fee
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}", follow=True
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
+        follow=True
     )
     content = json.loads(response.content)
     assert response.status_code == 403
@@ -620,8 +600,8 @@ def test_deposit_authenticated_success(client, acc1_usd_deposit_transaction_fact
     assert encoded_jwt
 
     header = {"HTTP_AUTHORIZATION": f"Bearer {encoded_jwt}"}
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
         follow=True,
         **header,
     )
@@ -634,8 +614,8 @@ def test_deposit_authenticated_success(client, acc1_usd_deposit_transaction_fact
 def test_deposit_no_jwt(client, acc1_usd_deposit_transaction_factory):
     """`GET /deposit` fails if a required JWT isn't provided."""
     deposit = acc1_usd_deposit_transaction_factory()
-    response = client.get(
-        f"/deposit?asset_code=USD&account={deposit.stellar_account}&memo=foo&memo_type=text",
+    response = client.post(
+        DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account, "memo_type": "text", "memo": "foo"},
         follow=True,
     )
     content = json.loads(response.content)

--- a/polaris/polaris/tests/deposit_test.py
+++ b/polaris/polaris/tests/deposit_test.py
@@ -193,8 +193,8 @@ def test_deposit_invalid_hash_memo(
 
 
 def test_deposit_confirm_no_txid(client):
-    """`GET /deposit/confirm_transaction` fails with no `transaction_id`."""
-    response = client.get(f"/deposit/confirm_transaction?amount=0", follow=True)
+    """`GET /transactions/deposit/confirm_transaction` fails with no `transaction_id`."""
+    response = client.get(f"/transactions/deposit/confirm_transaction?amount=0", follow=True)
     content = json.loads(response.content)
     assert response.status_code == 400
     assert content == {
@@ -205,10 +205,10 @@ def test_deposit_confirm_no_txid(client):
 
 @pytest.mark.django_db
 def test_deposit_confirm_invalid_txid(client):
-    """`GET /deposit/confirm_transaction` fails with an invalid `transaction_id`."""
+    """`GET /transactions/deposit/confirm_transaction` fails with an invalid `transaction_id`."""
     incorrect_transaction_id = uuid.uuid4()
     response = client.get(
-        f"/deposit/confirm_transaction?amount=0&transaction_id={incorrect_transaction_id}",
+        f"/transactions/deposit/confirm_transaction?amount=0&transaction_id={incorrect_transaction_id}",
         follow=True,
     )
     content = json.loads(response.content)
@@ -221,10 +221,10 @@ def test_deposit_confirm_invalid_txid(client):
 
 @pytest.mark.django_db
 def test_deposit_confirm_no_amount(client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit/confirm_transaction` fails with no `amount`."""
+    """`GET /transactions/deposit/confirm_transaction` fails with no `amount`."""
     deposit = acc1_usd_deposit_transaction_factory()
     response = client.get(
-        f"/deposit/confirm_transaction?transaction_id={deposit.id}", follow=True
+        f"/transactions/deposit/confirm_transaction?transaction_id={deposit.id}", follow=True
     )
     content = json.loads(response.content)
     assert response.status_code == 400
@@ -233,10 +233,10 @@ def test_deposit_confirm_no_amount(client, acc1_usd_deposit_transaction_factory)
 
 @pytest.mark.django_db
 def test_deposit_confirm_invalid_amount(client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit/confirm_transaction` fails with a non-float `amount`."""
+    """`GET /transactions/deposit/confirm_transaction` fails with a non-float `amount`."""
     deposit = acc1_usd_deposit_transaction_factory()
     response = client.get(
-        f"/deposit/confirm_transaction?transaction_id={deposit.id}&amount=foo",
+        f"/transactions/deposit/confirm_transaction?transaction_id={deposit.id}&amount=foo",
         follow=True,
     )
     content = json.loads(response.content)
@@ -249,11 +249,11 @@ def test_deposit_confirm_invalid_amount(client, acc1_usd_deposit_transaction_fac
 
 @pytest.mark.django_db
 def test_deposit_confirm_incorrect_amount(client, acc1_usd_deposit_transaction_factory):
-    """`GET /deposit/confirm_transaction` fails with an incorrect `amount`."""
+    """`GET /transactions/deposit/confirm_transaction` fails with an incorrect `amount`."""
     deposit = acc1_usd_deposit_transaction_factory()
     incorrect_amount = deposit.amount_in + 1
     response = client.get(
-        f"/deposit/confirm_transaction?transaction_id={deposit.id}&amount={incorrect_amount}",
+        f"/transactions/deposit/confirm_transaction?transaction_id={deposit.id}&amount={incorrect_amount}",
         follow=True,
     )
     content = json.loads(response.content)
@@ -273,12 +273,12 @@ def test_deposit_confirm_success(
     client,
     acc1_usd_deposit_transaction_factory,
 ):
-    """`GET /deposit/confirm_transaction` succeeds with correct `amount` and `transaction_id`."""
+    """`GET /transactions/deposit/confirm_transaction` succeeds with correct `amount` and `transaction_id`."""
     del mock_submit, mock_base_fee
     deposit = acc1_usd_deposit_transaction_factory()
     amount = deposit.amount_in
     response = client.get(
-        f"/deposit/confirm_transaction?amount={amount}&transaction_id={deposit.id}",
+        f"/transactions/deposit/confirm_transaction?amount={amount}&transaction_id={deposit.id}",
         follow=True,
     )
     assert response.status_code == 200
@@ -299,14 +299,14 @@ def test_deposit_confirm_external_id(
     client,
     acc1_usd_deposit_transaction_factory,
 ):
-    """`GET /deposit/confirm_transaction` successfully stores an `external_id`."""
+    """`GET /transactions/deposit/confirm_transaction` successfully stores an `external_id`."""
     del mock_submit, mock_base_fee
     deposit = acc1_usd_deposit_transaction_factory()
     amount = deposit.amount_in
     external_id = "foo"
     response = client.get(
         (
-            f"/deposit/confirm_transaction?amount={amount}&transaction_id="
+            f"/transactions/deposit/confirm_transaction?amount={amount}&transaction_id="
             f"{deposit.id}&external_transaction_id={external_id}"
         ),
         follow=True,
@@ -412,7 +412,7 @@ def test_deposit_interactive_confirm_success(
     acc1_usd_deposit_transaction_factory,
 ):
     """
-    `GET /deposit` and `GET /deposit/interactive_deposit` succeed with valid `account`
+    `GET /deposit` and `GET /transactions/deposit/webapp` succeed with valid `account`
     and `asset_code`.
     """
     del mock_check, mock_submit, mock_base_fee
@@ -436,7 +436,7 @@ def test_deposit_interactive_confirm_success(
     )
 
     response = client.get(
-        f"/deposit/confirm_transaction?amount={amount}&transaction_id={transaction_id}",
+        f"/transactions/deposit/confirm_transaction?amount={amount}&transaction_id={transaction_id}",
         follow=True,
     )
     assert response.status_code == 200
@@ -528,7 +528,7 @@ def test_deposit_check_trustlines_horizon(
     # Since the account will not have a trustline, the status will still
     # be `pending_trust`.
     response = client.get(
-        f"/deposit/confirm_transaction?amount={amount}&transaction_id={transaction_id}",
+        f"/transactions/deposit/confirm_transaction?amount={amount}&transaction_id={transaction_id}",
         follow=True,
     )
     assert response.status_code == 200

--- a/polaris/polaris/tests/deposit_test.py
+++ b/polaris/polaris/tests/deposit_test.py
@@ -620,5 +620,4 @@ def test_deposit_no_jwt(client, acc1_usd_deposit_transaction_factory):
     )
     content = json.loads(response.content)
     assert response.status_code == 400
-    print(content)
     assert content == {"error": "JWT must be passed as 'Authorization' header", "status_code": 400}

--- a/polaris/polaris/tests/withdraw_test.py
+++ b/polaris/polaris/tests/withdraw_test.py
@@ -56,11 +56,11 @@ def test_withdraw_interactive_no_txid(
     mock_check, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` fails with no transaction_id.
+    `GET /transactions/withdraw/webapp` fails with no transaction_id.
     """
     del mock_check
     acc1_usd_withdrawal_transaction_factory()
-    response = client.get(f"/withdraw/interactive_withdraw?", follow=True)
+    response = client.get(f"/transactions/withdraw/webapp?", follow=True)
     assert response.status_code == 400
 
 
@@ -70,12 +70,12 @@ def test_withdraw_interactive_no_asset(
     mock_check, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` fails with no asset_code.
+    `GET /transactions/withdraw/webapp` fails with no asset_code.
     """
     del mock_check
     acc1_usd_withdrawal_transaction_factory()
     response = client.get(
-        f"/withdraw/interactive_withdraw?transaction_id=2", follow=True
+        f"/transactions/withdraw/webapp?transaction_id=2", follow=True
     )
     assert response.status_code == 400
 
@@ -86,12 +86,12 @@ def test_withdraw_interactive_invalid_asset(
     mock_check, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` fails with invalid asset_code.
+    `GET /transactions/withdraw/webapp` fails with invalid asset_code.
     """
     del mock_check
     acc1_usd_withdrawal_transaction_factory()
     response = client.get(
-        f"/withdraw/interactive_withdraw?transaction_id=2&asset_code=ETH", follow=True
+        f"/transactions/withdraw/webapp?transaction_id=2&asset_code=ETH", follow=True
     )
     assert response.status_code == 400
 
@@ -110,7 +110,7 @@ def test_withdraw_interactive_failure_no_memotype(
     mock_check, mock_transactions, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` fails with no `memo_type` in Horizon response.
+    `GET /transactions/withdraw/webapp` fails with no `memo_type` in Horizon response.
     """
     del mock_check, mock_transactions
     acc1_usd_withdrawal_transaction_factory()
@@ -140,7 +140,7 @@ def test_withdraw_interactive_failure_incorrect_memotype(
     mock_check, mock_transactions, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` fails with incorrect `memo_type` in Horizon response.
+    `GET /transactions/withdraw/webapp` fails with incorrect `memo_type` in Horizon response.
     """
     del mock_check, mock_transactions
     acc1_usd_withdrawal_transaction_factory()
@@ -170,7 +170,7 @@ def test_withdraw_interactive_failure_no_memo(
     mock_check, mock_transactions, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` fails with no `memo` in Horizon response.
+    `GET /transactions/withdraw/webapp` fails with no `memo` in Horizon response.
     """
     del mock_check, mock_transactions
     acc1_usd_withdrawal_transaction_factory()
@@ -200,7 +200,7 @@ def test_withdraw_interactive_failure_incorrect_memo(
     mock_check, mock_transactions, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` fails with incorrect `memo` in Horizon response.
+    `GET /transactions/withdraw/webapp` fails with incorrect `memo` in Horizon response.
     """
     del mock_check, mock_transactions
     acc1_usd_withdrawal_transaction_factory()
@@ -226,7 +226,7 @@ def test_withdraw_interactive_success_transaction_unsuccessful(
     mock_check, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` changes transaction to `pending_stellar`
+    `GET /transactions/withdraw/webapp` changes transaction to `pending_stellar`
     with unsuccessful transaction.
     """
     del mock_check
@@ -265,7 +265,7 @@ def test_withdraw_interactive_success_transaction_successful(
     mock_check, client, acc1_usd_withdrawal_transaction_factory
 ):
     """
-    `GET /withdraw/interactive_withdraw` changes transaction to `completed`
+    `GET /transactions/withdraw/webapp` changes transaction to `completed`
     with successful transaction.
     """
     del mock_check

--- a/polaris/polaris/urls.py
+++ b/polaris/polaris/urls.py
@@ -17,11 +17,11 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
+    path(".well-known", include("polaris.stellartoml.urls")),
     path("info", include("polaris.info.urls")),
     path("fee", include("polaris.fee.urls")),
     path("", include("polaris.transaction.urls")),
-    path("deposit", include("polaris.deposit.urls")),
-    path(".well-known", include("polaris.stellartoml.urls")),
-    path("withdraw", include("polaris.withdraw.urls")),
+    path("", include("polaris.deposit.urls")),
+    path("", include("polaris.withdraw.urls")),
     path("auth", include("polaris.sep10auth.urls")),
 ]

--- a/polaris/polaris/withdraw/urls.py
+++ b/polaris/polaris/withdraw/urls.py
@@ -5,5 +5,5 @@ from polaris.withdraw.views import withdraw, interactive_withdraw
 
 urlpatterns = [
     path("transactions/withdraw/interactive", csrf_exempt(withdraw)),
-    path("withdraw/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
+    path("transactions/withdraw/webapp", interactive_withdraw, name="interactive_withdraw"),
 ]

--- a/polaris/polaris/withdraw/urls.py
+++ b/polaris/polaris/withdraw/urls.py
@@ -1,8 +1,9 @@
 """This module defines the URL patterns for the `/withdraw` endpoint."""
 from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
 from polaris.withdraw.views import withdraw, interactive_withdraw
 
 urlpatterns = [
-    path("", withdraw),
-    path("/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
+    path("transactions/withdraw/interactive", csrf_exempt(withdraw)),
+    path("withdraw/interactive_withdraw", interactive_withdraw, name="interactive_withdraw"),
 ]

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -13,7 +13,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
-from rest_framework.renderers import TemplateHTMLRenderer
+from rest_framework.renderers import TemplateHTMLRenderer, JSONRenderer
 
 from polaris.helpers import (
     render_error_response,
@@ -26,11 +26,11 @@ from polaris.transaction.serializers import TransactionSerializer
 from polaris.withdraw.forms import WithdrawForm
 
 
-def _construct_interactive_url(request, transaction_id):
+def _construct_interactive_url(request, asset_code, transaction_id):
     """Constructs the URL for the interactive application for withdrawal info.
     This is located at `/withdraw/interactive_withdraw`."""
     qparams = urlencode(
-        {"asset_code": request.GET.get("asset_code"), "transaction_id": transaction_id}
+        {"asset_code": asset_code, "transaction_id": transaction_id}
     )
     path = reverse("interactive_withdraw")
     url_params = f"{path}?{qparams}"
@@ -121,14 +121,15 @@ def interactive_withdraw(request):
     return Response({"form": form}, template_name="withdraw/form.html")
 
 
-@api_view()
+@api_view(["POST"])
 @validate_sep10_token()
+@renderer_classes([JSONRenderer])
 def withdraw(request):
     """
-    `GET /withdraw` initiates the withdrawal and returns an interactive
+    `POST /withdraw` initiates the withdrawal and returns an interactive
     withdrawal form to the user.
     """
-    asset_code = request.GET.get("asset_code")
+    asset_code = request.POST.get("asset_code")
     if not asset_code:
         return render_error_response("'asset_code' is required")
 
@@ -140,8 +141,7 @@ def withdraw(request):
         return render_error_response(f"invalid operation for asset {asset_code}")
 
     transaction_id = create_transaction_id()
-    url = _construct_interactive_url(request, transaction_id)
+    url = _construct_interactive_url(request, asset_code, transaction_id)
     return Response(
         {"type": "interactive_customer_info_needed", "url": url, "id": transaction_id},
-        status=status.HTTP_403_FORBIDDEN,
     )

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -28,7 +28,7 @@ from polaris.withdraw.forms import WithdrawForm
 
 def _construct_interactive_url(request, asset_code, transaction_id):
     """Constructs the URL for the interactive application for withdrawal info.
-    This is located at `/withdraw/interactive_withdraw`."""
+    This is located at `/transactions/withdraw/webapp`."""
     qparams = urlencode(
         {"asset_code": asset_code, "transaction_id": transaction_id}
     )
@@ -51,7 +51,7 @@ def _construct_more_info_url(request):
 @renderer_classes([TemplateHTMLRenderer])
 def interactive_withdraw(request):
     """
-    `GET /withdraw/interactive_withdraw` opens a form used to input information about
+    `GET /transactions/withdraw/webapp` opens a form used to input information about
     the withdrawal. This creates a corresponding transaction in our database.
     """
     transaction_id = request.GET.get("transaction_id")


### PR DESCRIPTION
Only one change is included in 0.9.2: https://github.com/stellar/django-polaris/pull/6

I want to review this change again. Here are a few things I'm seeing:
- The SEP-24 protocol documentation and doc strings (less important) aren't up to date. Particularly, `/deposit` and `/withdraw` are no longer listed in the API Endpoints section but they are still referenced throughout the document. This ties into my next point.
- This change moves `/deposit` to `/transactions/deposit/interactive` but also keeps `/deposit/confirm_transaction` and `/deposit/interactive_deposit` where they are
    - The SEP and PR appear to communicate that `/deposit` and `/withdraw` were completely removed. I personally feel like we should either move all `/deposit` and `/withdraw` routes under `/transactions`, or none at all. Right now, its hard to understand the reasoning behind why we moved `/deposit` if we were planning to keep the other endpoints the same.
    - It is no longer clear what the difference is between `/transactions/deposit/interactive` and `deposit/interactive_deposit`. I think having `/transactions/deposit` and `/transactions/deposit/interactive` makes more sense.