### PR TITLE
Removed /confirm_transaction

### DIFF
--- a/polaris/polaris/deposit/urls.py
+++ b/polaris/polaris/deposit/urls.py
@@ -1,10 +1,9 @@
 """This module defines the URL patterns for the `/deposit` endpoint."""
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
-from polaris.deposit.views import deposit, interactive_deposit, confirm_transaction
+from polaris.deposit.views import deposit, interactive_deposit
 
 urlpatterns = [
     path("transactions/deposit/interactive", csrf_exempt(deposit)),
-    path("transactions/deposit/webapp", interactive_deposit, name="interactive_deposit"),
-    path("transactions/deposit/confirm_transaction", confirm_transaction, name="confirm_transaction"),
+    path("transactions/deposit/webapp", interactive_deposit, name="interactive_deposit")
 ]

--- a/polaris/polaris/templates/transaction/more_info.html
+++ b/polaris/polaris/templates/transaction/more_info.html
@@ -94,37 +94,6 @@
             // }
             targetWindow.postMessage(tx_json, "*");
         }
-
-        // Confirm an uncompleted deposit transaction.
-        function submitExternal() {
-            var transactionId, amount, xhr;
-            transactionId = transaction["id"];
-            amount = transaction["amount_in"];
-            xhr = new XMLHttpRequest();
-            xhrUrl = '/transactions/deposit/confirm_transaction?transaction_id=' + transactionId + '&amount=' + amount;
-            xhr.open('get', xhrUrl, true);
-            xhr.onload = function () {
-                if (this.status >= 200 && this.status < 400) {
-                    postTransactionCallback();
-                }
-            }
-            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
-            xhr.send();
-            return false;
-        }
     </script>
 </section>
-{% endblock %}
-
-{% block "footer" %}
-{% if transaction.status != "completed" %}
-    <div class="at-bottom button-row">
-        {% if transaction.kind == "deposit" %}
-            <button type="button" class="button-main" onclick="return submitExternal()">Admin: Confirm external transaction.</button>
-
-        {% endif %}
-        <div class="spacer"></div>
-        <button type="button" class="button-secondary refresh-icon" onclick="location.reload(true);"></button>
-    </div>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
Removed the `/confirm_transaction` endpoint. The client-side call to this endpoint should be removed if it hasn't already been @msfeldstein.

This endpoint can be removed because we added the `poll_pending_deposits` docker container process, which periodically checks for transactions that are ready to be execute on the stellar network (a.k.a. the user has deposited the amount in the anchors account). If a transaction is ready, the same code from `/confirm_transaction` is executed.

Michael, can you confirm the changes to the JavaScript/HTML are good? I removed the "confirm" button and call to `/confirm_transaction`. We don't need the button, but should we replace it with some kind of indicator that the wallet is waiting for the anchor to execute the transaction?