### PR TITLE
Deposit Instructions

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -75,6 +75,11 @@ The `attrs` parameter adds a HTML attribute to the `<input>` tag that Bulma
 uses to add better styling. You may also add more Bulma-supported attributes
 to Polaris forms.
 
+Deposit Instructions
+--------------------
+
+.. autofunction:: polaris.integrations.DepositIntegration.instructions_for_pending_deposit
+
 Registering Integrations
 ------------------------
 In order for Polaris to use the integration classes you've defined, you

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -138,6 +138,19 @@ class DepositIntegration:
         """
         pass
 
+    @classmethod
+    def instructions_for_pending_deposit(cls, transaction: Transaction):
+        """
+        For pending deposits, its common to show instructions to the user for how
+        to initiate the external transfer. Use this function to return text or HTML
+        instructions to be rendered in response to `/transaction/more_info`.
+
+        :param transaction: the transaction database object to be serialized and
+            rendered in the response.
+        :return: the text or HTML to render in the instructions template section
+        """
+        pass
+
 
 class WithdrawalIntegration:
     """

--- a/polaris/polaris/templates/transaction/more_info.html
+++ b/polaris/polaris/templates/transaction/more_info.html
@@ -9,7 +9,7 @@
     {% if instructions is not none %}
     <div class="field">
         <label>
-            Instructions
+            instructions
         </label>
         <div class="field-value">
             {{ instructions|safe }}

--- a/polaris/polaris/templates/transaction/more_info.html
+++ b/polaris/polaris/templates/transaction/more_info.html
@@ -6,6 +6,16 @@
 
 {% block "content" %}
 <section class="section receipt">
+    {% if instructions is not none %}
+    <div class="field">
+        <label>
+            Instructions
+        </label>
+        <div class="field-value">
+            {{ instructions|safe }}
+        </div>
+    </div>
+    {% endif %}
     <div class="field">
         <label>
             kind
@@ -59,7 +69,7 @@
             {{ transaction.completed_at }}
         </div>
     </div>
-    
+
     <script type="text/javascript">
         var tx_json = JSON.parse('{{ tx_json|safe }}');
         var transaction = tx_json["transaction"];

--- a/polaris/polaris/transaction/views.py
+++ b/polaris/polaris/transaction/views.py
@@ -12,9 +12,10 @@ from polaris import settings
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
 
-from polaris.helpers import render_error_response, validate_sep10_token, validate_jwt_request
+from polaris.helpers import render_error_response, validate_sep10_token
 from polaris.models import Transaction
 from polaris.transaction.serializers import TransactionSerializer
+from polaris.integrations import registered_deposit_integration as rdi
 
 
 def _validate_limit(limit):
@@ -98,14 +99,16 @@ def more_info(request: Request) -> Response:
         context={"more_info_url": _construct_more_info_url(request)},
     )
     tx_json = json.dumps({"transaction": serializer.data})
-    return Response(
-        {
-            "tx_json": tx_json,
-            "transaction": request_transaction,
-            "asset_code": request_transaction.asset.code,
-        },
-        template_name="transaction/more_info.html"
-    )
+    resp_data = {
+        "tx_json": tx_json,
+        "transaction": request_transaction,
+        "asset_code": request_transaction.asset.code,
+        "instructions": None
+    }
+    if (transaction.kind == Transaction.KIND.deposit and
+            transaction.status == Transaction.STATUS.pending_user_transfer_start):
+        resp_data["instructions"] = rdi.instructions_for_pending_deposit(transaction)
+    return Response(resp_data, template_name="transaction/more_info.html")
 
 
 @api_view()

--- a/polaris/polaris/transaction/views.py
+++ b/polaris/polaris/transaction/views.py
@@ -105,8 +105,8 @@ def more_info(request: Request) -> Response:
         "asset_code": request_transaction.asset.code,
         "instructions": None
     }
-    if (transaction.kind == Transaction.KIND.deposit and
-            transaction.status == Transaction.STATUS.pending_user_transfer_start):
+    if (request_transaction.kind == Transaction.KIND.deposit and
+            request_transaction.status == Transaction.STATUS.pending_user_transfer_start):
         resp_data["instructions"] = rdi.instructions_for_pending_deposit(transaction)
     return Response(resp_data, template_name="transaction/more_info.html")
 


### PR DESCRIPTION
Issue #26 

Changes:
- Added `instructions_for_pending_deposit` to `DepositIntegration`
- Call `instructions_for_pending_deposit` in more_info if transaction is `pending_user_transfer_start`
- Adjust `more_info.html` template to include "Instructions" section when `instructions` is not null