### PR TITLE
Fixed /transactions more_info response attribute

### DIFF
--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -55,15 +55,6 @@ def _construct_interactive_url(
     return request.build_absolute_uri(url_params)
 
 
-def _construct_more_info_url(request):
-    """Constructs the more info URL for a deposit."""
-    qparams_dict = {"id": request.GET.get("transaction_id")}
-    qparams = urlencode(qparams_dict)
-    path = reverse("more_info")
-    path_params = f"{path}?{qparams}"
-    return request.build_absolute_uri(path_params)
-
-
 # TODO: The interactive pop-up will be used to retrieve additional info,
 # so we should not need to validate these parameters. Alternately, we can
 # pass these to the pop-up.

--- a/polaris/polaris/transaction/serializers.py
+++ b/polaris/polaris/transaction/serializers.py
@@ -30,17 +30,13 @@ class TransactionSerializer(serializers.ModelSerializer):
     more_info_url = serializers.SerializerMethodField()
 
     def get_more_info_url(self, transaction_instance):
-        url_from_context = self.context.get("more_info_url")
-        if url_from_context:
-            return url_from_context
-
         request_from_context = self.context.get("request")
-        if request_from_context:
-            path = reverse("more_info")
-            path_params = f"{path}?id={transaction_instance.id}"
-            return request_from_context.build_absolute_uri(path_params)
+        if not request_from_context:
+            raise ValueError("Unable to construct url for transaction.")
 
-        raise ValueError("Unable to construct url for transaction.")
+        path = reverse("more_info")
+        path_params = f"{path}?id={transaction_instance.id}"
+        return request_from_context.build_absolute_uri(path_params)
 
     def to_representation(self, instance):
         """

--- a/polaris/polaris/transaction/serializers.py
+++ b/polaris/polaris/transaction/serializers.py
@@ -1,5 +1,9 @@
 """This module defines a serializer for the transaction model."""
+from urllib.parse import urlencode
+
 from rest_framework import serializers
+from rest_framework.request import Request
+from django.urls import reverse
 
 from polaris.models import Transaction
 
@@ -26,7 +30,17 @@ class TransactionSerializer(serializers.ModelSerializer):
     more_info_url = serializers.SerializerMethodField()
 
     def get_more_info_url(self, transaction_instance):
-        return self.context.get("more_info_url")
+        url_from_context = self.context.get("more_info_url")
+        if url_from_context:
+            return url_from_context
+
+        request_from_context = self.context.get("request")
+        if request_from_context:
+            path = reverse("more_info")
+            path_params = f"{path}?id={transaction_instance.id}"
+            return request_from_context.build_absolute_uri(path_params)
+
+        raise ValueError("Unable to construct url for transaction.")
 
     def to_representation(self, instance):
         """

--- a/polaris/polaris/transaction/views.py
+++ b/polaris/polaris/transaction/views.py
@@ -158,9 +158,7 @@ def transactions(account: str, request: Request) -> Response:
 
     transactions_qset = Transaction.objects.filter(**qset_filter)[:limit]
     serializer = TransactionSerializer(
-        transactions_qset,
-        many=True,
-        context={"more_info_url": _construct_more_info_url(request)},
+        transactions_qset, many=True, context={"request": request},
     )
 
     return Response({"transactions": serializer.data})

--- a/polaris/polaris/transaction/views.py
+++ b/polaris/polaris/transaction/views.py
@@ -57,24 +57,6 @@ def _get_transaction_from_request(request, account: str = None):
     return Transaction.objects.get(**qset_filter)
 
 
-def _construct_more_info_url(request):
-    qparams_dict = {}
-    transaction_id = request.GET.get("id")
-    if transaction_id:
-        qparams_dict["id"] = transaction_id
-    stellar_transaction_id = request.GET.get("stellar_transaction_id")
-    if stellar_transaction_id:
-        qparams_dict["stellar_transaction_id"] = stellar_transaction_id
-    external_transaction_id = request.GET.get("external_transaction_id")
-    if external_transaction_id:
-        qparams_dict["external_transaction_id"] = external_transaction_id
-
-    qparams = urlencode(qparams_dict)
-    path = reverse("more_info")
-    path_params = f"{path}?{qparams}"
-    return request.build_absolute_uri(path_params)
-
-
 @xframe_options_exempt
 @api_view()
 @renderer_classes([TemplateHTMLRenderer])
@@ -95,8 +77,7 @@ def more_info(request: Request) -> Response:
         )
 
     serializer = TransactionSerializer(
-        request_transaction,
-        context={"more_info_url": _construct_more_info_url(request)},
+        request_transaction, context={"request": request}
     )
     tx_json = json.dumps({"transaction": serializer.data})
     resp_data = {
@@ -180,7 +161,6 @@ def transaction(account: str, request: Request) -> Response:
             "transaction not found", status_code=status.HTTP_404_NOT_FOUND
         )
     serializer = TransactionSerializer(
-        request_transaction,
-        context={"more_info_url": _construct_more_info_url(request)},
+        request_transaction, context={"request": request},
     )
     return Response({"transaction": serializer.data})

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -45,15 +45,6 @@ def _construct_interactive_url(
     return request.build_absolute_uri(url_params)
 
 
-def _construct_more_info_url(request):
-    """Constructs the more info URL for a withdraw."""
-    qparams_dict = {"id": request.GET.get("transaction_id")}
-    qparams = urlencode(qparams_dict)
-    path = reverse("more_info")
-    path_params = f"{path}?{qparams}"
-    return request.build_absolute_uri(path_params)
-
-
 @xframe_options_exempt
 @api_view(["POST"])
 @renderer_classes([TemplateHTMLRenderer])


### PR DESCRIPTION
#47 

The `/transactions` endpoint was attempting to generate a single more_info URL for a list of transactions. The changes ensure each transaction in the response has its own more_info URL.