### PR TITLE
Serve pages with no form in the interactive flow

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -35,27 +35,22 @@ Form Integrations
 
 .. _Django Forms: https://docs.djangoproject.com/en/2.2/topics/forms/#forms-in-django
 
-Polaris uses `Django Forms`_ for collecting users' information, such as their
-email or how much of their asset they want to deposit. Polaris comes out of
-the box with forms for deposit and withdrawal flows.
+Polaris provides a set of integration functions that allow you to collect,
+validate, and process the information you need to collect from users with
+`Django Forms`_.
 
-However, the data collected may not be sufficient for your needs. Maybe you
-need to collect additional fields and do some validation or processing with
-the data that Polaris doesn't already do. Maybe you need to serve more forms
-than just the one to collect transaction information.
+For example, you'll need to collect the amount the user would like to deposit
+or withdraw. Polaris provides a `TransactionForm` that can be subclassed to
+add additional fields for this purpose. The definition can be found in the
+:doc:`../forms/index` documentation.
 
-That is why Polaris provides a set of integration functions that allow you
-to collect, validate, and process the information you need with as many forms
-as you want. The set of functions documented below outline how Polaris
-supports a customizable interactive flow.
+The functions below facilitate the process of collecting the information needed.
 
-See the :doc:`../forms/index` documentation for the `TransactionForm` definition.
-
-.. autofunction:: polaris.integrations.DepositIntegration.form_for_transaction
+.. autofunction:: polaris.integrations.DepositIntegration.content_for_transaction
 
 .. autofunction:: polaris.integrations.DepositIntegration.after_form_validation
 
-.. autofunction:: polaris.integrations.WithdrawalIntegration.form_for_transaction
+.. autofunction:: polaris.integrations.WithdrawalIntegration.content_for_transaction
 
 .. autofunction:: polaris.integrations.WithdrawalIntegration.after_form_validation
 

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -158,7 +158,8 @@ def get_interactive_deposit(request: Request) -> Response:
 
     url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
     post_url = f"{reverse('post_interactive_deposit')}?{urlencode(url_args)}"
-    content.update(post_url=post_url)
+    get_url = f"{reverse('get_interactive_deposit')}?{urlencode(url_args)}"
+    content.update(post_url=post_url, get_url=get_url)
 
     return Response(content, template_name="deposit/form.html")
 

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -110,6 +110,11 @@ class DepositIntegration:
         collecting KYC data, return a :class:`forms.Form` with the fields you
         need.
 
+        You can also return a dictionary without a ``form`` key. You should do
+        this if you are waiting on the user to take some action, like confirming
+        their email. Once confirmed, the next call to this function should return
+        the next form.
+
         This loop of submitting a form, validating & processing it, and checking
         for the next form will continue until this function returns ``None``.
 

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -72,12 +72,10 @@ class DepositIntegration:
         pass
 
     @classmethod
-    def form_for_transaction(
-        cls, transaction: Transaction
-    ) -> Optional[Tuple[Type[forms.Form], Dict]]:
+    def content_for_transaction(cls, transaction: Transaction) -> Optional[Dict]:
         """
-        This function should return the next form class to render for the user
-        given the state of the interactive flow.
+        This function should return a dictionary containing the next form class
+        to render for the user given the state of the interactive flow.
 
         For example, this function should return a :class:`TransactionForm` to
         get the amount that should be transferred. Once the form is submitted,
@@ -85,13 +83,14 @@ class DepositIntegration:
         and update the ``amount_in`` column with the amount specified in form.
 
         The form will be rendered inside a django template that has several
-        pieces of content that can and should be replaced by also returning a
+        pieces of content that can be replaced by also returning a
         dictionary containing the key-value pairs as shown below.
         ::
 
-            def form_for_transaction(cls, transaction):
+            def content_for_transaction(cls, transaction):
                 ...
-                return TransactionForm, {
+                return {
+                    "form": TransactionForm,
                     "title": "Deposit Transaction Form",
                     "guidance": "Please enter the amount you would like to deposit.",
                     "icon_label": "Stellar Development Foundation"
@@ -131,15 +130,15 @@ class DepositIntegration:
             # and don't implement KYC by default
             return
 
-        return TransactionForm, {}
+        return {"form": TransactionForm}
 
     @classmethod
     def after_form_validation(cls, form: forms.Form, transaction: Transaction):
         """
         Use this function to process the data collected with `form` and to update
         the state of the interactive flow so that the next call to
-        :func:`DepositIntegration.form_for_transaction` returns the next form
-        to render to the user, or None.
+        :func:`DepositIntegration.content_for_transaction` returns a dictionary
+        containing the next form to render to the user, or returns None.
 
         Keep in mind that if a :class:`TransactionForm` is submitted, Polaris will
         update the `amount_in` and `amount_fee` with the information collected.
@@ -150,7 +149,7 @@ class DepositIntegration:
         particular values at different points in the flow.
 
         If you need to store some data to determine which form to return next when
-        :func:`DepositIntegration.form_for_transaction` is called, store this
+        :func:`DepositIntegration.content_for_transaction` is called, store this
         data in a model not used by Polaris.
 
         :param form: the completed :class:`forms.Form` submitted by the user
@@ -225,11 +224,9 @@ class WithdrawalIntegration:
         )
 
     @classmethod
-    def form_for_transaction(
-        cls, transaction: Transaction
-    ) -> Optional[Tuple[Type[forms.Form], Dict]]:
+    def content_for_transaction(cls, transaction: Transaction) -> Optional[Dict]:
         """
-        Same as :func:`DepositIntegration.form_for_transaction`, except:
+        Same as :func:`DepositIntegration.content_for_transaction`, except:
 
         When this function returns ``None``, Polaris will update the Transaction
         status to ``pending_external``. Once the wallet submits the
@@ -245,7 +242,7 @@ class WithdrawalIntegration:
             # and don't implement KYC by default
             return
 
-        return WithdrawForm, {}
+        return {"form": WithdrawForm}
 
     @classmethod
     def after_form_validation(cls, form: TransactionForm, transaction: Transaction):

--- a/polaris/polaris/templates/deposit/form.html
+++ b/polaris/polaris/templates/deposit/form.html
@@ -13,32 +13,37 @@
     <i>Please fill out the fields below.</i>
   {% endif %}
 
-  <form method="post" action="{{ post_url }}">
-    {% csrf_token %}
+  {% if form is not None %}
+    <form method="post" action="{{ post_url }}">
+      {% csrf_token %}
 
-    {% for field in form %}
-      <div class="field">
-        <label>
-          <div class="label">{{ field.label }}</div>
-          <div class="control"> {{ field }} </div>
-        </label>
+      {% for field in form %}
+        <div class="field">
+          <label>
+            <div class="label">{{ field.label }}</div>
+            <div class="control"> {{ field }} </div>
+          </label>
 
-        {% if field.errors %}
-        <p class="help is-danger">
-          {% for error in field.errors %}
-          {{ error }}
-          {% endfor %}
-        </p>
-        {% endif %}
+          {% if field.errors %}
+          <p class="help is-danger">
+            {% for error in field.errors %}
+            {{ error }}
+            {% endfor %}
+          </p>
+          {% endif %}
 
+        </div>
+      {% endfor %}
+
+      <div class="field at-bottom">
+        <div class="control">
+            <button class="button" type="submit">Submit</button>
+        </div>
       </div>
-    {% endfor %}
-
-    <div class="field at-bottom">
-      <div class="control">
-        <button class="button" type="submit">Submit</button>
-      </div>
-    </div>
-  </form>
+    </form>
+  {% else %}
+    <br><br>
+    <button class="button" onClick="location.href='{{ get_url }}'">Refresh</button>
+  {% endif %}
 </section>
 {% endblock %}

--- a/polaris/polaris/templates/withdraw/form.html
+++ b/polaris/polaris/templates/withdraw/form.html
@@ -12,30 +12,36 @@
     {% else %}
       <i>Please fill out the fields below.</i>
     {% endif %}
-    <form method="post" action="{{ post_url }}">
-        {% csrf_token %}
 
-        {% for field in form %}
-        <div class="field">
-            <label class="label"> {{ field.label }}</label>
-            <div class="control"> {{ field }} </div>
+    {% if form is not None %}
+        <form method="post" action="{{ post_url }}">
+            {% csrf_token %}
 
-            {% if field.errors %}
-            <p class="help is-danger">
-                {% for error in field.errors %}
-                {{ error }}
-                {% endfor %}
-            </p>
-            {% endif %}
+            {% for field in form %}
+            <div class="field">
+                <label class="label"> {{ field.label }}</label>
+                <div class="control"> {{ field }} </div>
 
-        </div>
-        {% endfor %}
+                {% if field.errors %}
+                <p class="help is-danger">
+                    {% for error in field.errors %}
+                    {{ error }}
+                    {% endfor %}
+                </p>
+                {% endif %}
 
-        <div class="field">
-            <div class="control">
-                <button class="button is-link" type="submit">Continue</button>
             </div>
-        </div>
-    </form>
+            {% endfor %}
+
+            <div class="field">
+                <div class="control">
+                    <button class="button is-link" type="submit">Continue</button>
+                </div>
+            </div>
+        </form>
+    {% else %}
+        <br><br>
+        <button class="button" onClick="location.href='{{ get_url }}'">Refresh</button>
+    {% endif %}
 </section>
 {% endblock %}

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -149,7 +149,6 @@ def withdraw(account: str, request: Request) -> Response:
     if not asset or not asset.withdrawal_enabled:
         return render_error_response(f"invalid operation for asset {asset_code}")
     elif asset.code not in settings.ASSETS:
-        print(settings.ASSETS)
         return render_error_response(f"unsupported asset type: {asset_code}")
     distribution_address = settings.ASSETS[asset.code]["DISTRIBUTION_ACCOUNT_ADDRESS"]
 

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -124,7 +124,8 @@ def get_interactive_withdraw(request: Request) -> Response:
 
     url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
     post_url = f"{reverse('post_interactive_withdraw')}?{urlencode(url_args)}"
-    content.update(post_url=post_url)
+    get_url = f"{reverse('get_interactive_withdraw')}?{urlencode(url_args)}"
+    content.update(post_url=post_url, get_url=get_url)
 
     return Response(content, template_name="withdraw/form.html")
 
@@ -148,6 +149,7 @@ def withdraw(account: str, request: Request) -> Response:
     if not asset or not asset.withdrawal_enabled:
         return render_error_response(f"invalid operation for asset {asset_code}")
     elif asset.code not in settings.ASSETS:
+        print(settings.ASSETS)
         return render_error_response(f"unsupported asset type: {asset_code}")
     distribution_address = settings.ASSETS[asset.code]["DISTRIBUTION_ACCOUNT_ADDRESS"]
 

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -22,6 +22,7 @@ from polaris.helpers import (
     authenticate_session,
     invalidate_session,
     interactive_args_validation,
+    check_middleware,
 )
 from polaris.models import Asset, Transaction
 from polaris.integrations.forms import TransactionForm
@@ -39,9 +40,17 @@ def post_interactive_withdraw(request: Request) -> Response:
     if error_resp:
         return error_resp
 
-    form_class, _ = rwi.form_for_transaction(transaction)
+    content = rwi.content_for_transaction(transaction)
+    if not (content and content.get("form")):
+        return render_error_response(
+            "The anchor did not provide a content, unable to serve page.",
+            status_code=500,
+            content_type="text/html",
+        )
+
+    form_class = content.get("form")
     form = form_class(request.POST)
-    is_transaction_form = issubclass(form.__class__, TransactionForm)
+    is_transaction_form = issubclass(form_class, TransactionForm)
     if is_transaction_form:
         form.asset = asset
 
@@ -53,12 +62,15 @@ def post_interactive_withdraw(request: Request) -> Response:
             )
             transaction.save()
 
-        # Perform any defined post-validation logic defined by Polaris users
+        # Perform any defined post-validation logic defined by Polaris users.
+        # If the anchor wants to return another form, this function should
+        # change the application state such that the next call to
+        # content_for_transaction() returns the next form.
         rwi.after_form_validation(form, transaction)
-        # Check to see if there is another form to render
-        form_data = rwi.form_for_transaction(transaction)
 
-        if form_data:
+        # Check to see if there is another form to render
+        content = rwi.content_for_transaction(transaction)
+        if content:
             args = {"transaction_id": transaction.id, "asset_code": asset.code}
             url = reverse("get_interactive_withdraw")
             return redirect(f"{url}?{urlencode(args)}")
@@ -90,24 +102,31 @@ def get_interactive_withdraw(request: Request) -> Response:
     """
     Validates the arguments and serves the next form to process
     """
+    err_resp = check_middleware()
+    if err_resp:
+        return err_resp
+
     transaction, asset, error_resp = interactive_args_validation(request)
     if error_resp:
         return error_resp
 
-    try:
-        form_class, context = rwi.form_for_transaction(transaction)
-    except TypeError:
+    content = rwi.content_for_transaction(transaction)
+    if not content:
         return render_error_response(
             "The anchor did not provide a form, unable to serve page.",
             status_code=500,
             content_type="text/html",
         )
 
+    if content.get("form"):
+        form_class = content.pop("form")
+        content["form"] = form_class()
+
     url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
     post_url = f"{reverse('post_interactive_withdraw')}?{urlencode(url_args)}"
-    resp_data = {"form": form_class(), "post_url": post_url}
-    resp_data.update(context)
-    return Response(resp_data, template_name="withdraw/form.html")
+    content.update(post_url=post_url)
+
+    return Response(content, template_name="withdraw/form.html")
 
 
 @api_view(["POST"])


### PR DESCRIPTION
#78 

Major Changes:
- Renamed `form_for_transaction` to `content_for_transaction`
    - This is a better name since we're returning the form _plus_ text content to be rendered in the HTML
- Changed the return type of `content_for_transaction` to a dictionary instead of the tuple
    - This is a better design since you can always expect 1 return value, not multiple or `None`
- Support serving pages without forms during the interactive flow
    - This would be needed if the user needs to take some action before continuing with the flow, like  confirming their email