### PR TITLE
gitignore sqlite db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+polaris/db.sqlite3


### PR DESCRIPTION
Since we create a sqlite database when we run locally we should ignore it so it doesn't get added to the repo