### PR TITLE
check_trustlines() now checks asset_issuer and limit as well

### DIFF
--- a/polaris/polaris/management/commands/check_trustlines.py
+++ b/polaris/polaris/management/commands/check_trustlines.py
@@ -73,6 +73,7 @@ class Command(BaseCommand):
                     asset_issuer = balance["asset_issuer"]
                     limit = float(balance["limit"])
                 except KeyError:
+                    logger.debug(f'balance {balance}')
                     if balance.get("asset_type") != "native":
                         logger.debug(
                             f"horizon balance had no asset_code for account {account['id']}"

--- a/polaris/polaris/management/commands/check_trustlines.py
+++ b/polaris/polaris/management/commands/check_trustlines.py
@@ -78,6 +78,11 @@ class Command(BaseCommand):
                             f"horizon balance had no asset_code for account {account['id']}"
                         )
                     continue
+                logger.debug(f'asset_code: {asset_code}')
+                logger.debug(f'asset_issuer: {asset_issuer}')
+                logger.debug(f'limit: {limit}')
+                logger.debug(f'transaction.asset.code: {transaction.asset.code}')
+                logger.debug(f'transaction.asset.issuer: {transaction.asset.issuer}')
                 if (asset_code == transaction.asset.code
                         and asset_issuer == transaction.asset.issuer
                         and limit > 0):

--- a/polaris/polaris/management/commands/check_trustlines.py
+++ b/polaris/polaris/management/commands/check_trustlines.py
@@ -70,13 +70,17 @@ class Command(BaseCommand):
             for balance in balances:
                 try:
                     asset_code = balance["asset_code"]
+                    asset_issuer = balance["asset_issuer"]
+                    limit = float(balance["limit"])
                 except KeyError:
                     if balance.get("asset_type") != "native":
                         logger.debug(
                             f"horizon balance had no asset_code for account {account['id']}"
                         )
                     continue
-                if asset_code == transaction.asset.code:
+                if (asset_code == transaction.asset.code
+                        and asset_issuer == transaction.asset.issuer
+                        and limit > 0):
                     logger.info(
                         f"Account {account['id']} has established a trustline for {asset_code}, "
                         f"initiating deposit for {transaction.id}"


### PR DESCRIPTION
There can be multiple assets with the same asset code from different issuers, so the issuer needs to be checked as well.
The account might contain balance for an asset but not have the trustline, in this case the balance is 0 and limit is 0. A limit higher than 0 means the trustline exists.