### PR TITLE
Pass page_content to registered script func

### DIFF
--- a/example/server/apps.py
+++ b/example/server/apps.py
@@ -18,6 +18,6 @@ class AnchorConfig(AppConfig):
             deposit=MyDepositIntegration(),
             withdrawal=MyWithdrawalIntegration(),
             toml_func=get_stellar_toml,
-            javascript_func=scripts,
+            scripts_func=scripts,
             fee_func=calculate_custom_fee,
         )

--- a/example/server/integrations.py
+++ b/example/server/integrations.py
@@ -313,8 +313,8 @@ def get_stellar_toml():
     }
 
 
-def scripts():
-    return [
+def scripts(page_content: Optional[Dict]):
+    tags = [
         # Google Analytics
         """
         <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -325,23 +325,24 @@ def scripts():
           gtag('js', new Date());
           gtag('config', 'UA-53373928-6');
         </script>
-        """,
+        """
+    ]
+    if "form" not in page_content and page_content.get("title") == _("Confirm Email"):
         # Refresh the confirm email page whenever the user brings the popup
         # back into focus. This is not strictly necessary since deposit.html
         # and withdraw.html have 'Refresh' buttons, but this is a better UX.
-        """
-        <script>
-            window.addEventListener("focus", () => {
-                if (document.title === "%s") {
+        tags.append(
+            """
+            <script>
+                window.addEventListener("focus", () => {
                     // Hit the /webapp endpoint again to check if the user's 
                     // email has been confirmed.
                     window.location.reload(true);
-                }
-            });
-        </script>
-        """
-        % CONFIRM_EMAIL_PAGE_TITLE,
-    ]
+                });
+            </script>
+            """
+        )
+    return tags
 
 
 def calculate_custom_fee(fee_params: Dict) -> Decimal:

--- a/example/server/integrations.py
+++ b/example/server/integrations.py
@@ -117,7 +117,7 @@ def check_kyc(transaction: Transaction) -> Optional[Dict]:
         }
     elif server_settings.EMAIL_HOST_USER and not account.user.confirmed:
         return {
-            "title": _("Confirm Email"),
+            "title": CONFIRM_EMAIL_PAGE_TITLE,
             "guidance": _(
                 "We sent you a confirmation email. Once confirmed, "
                 "continue on this page."
@@ -327,7 +327,10 @@ def scripts(page_content: Optional[Dict]):
         </script>
         """
     ]
-    if "form" not in page_content and page_content.get("title") == _("Confirm Email"):
+    if (
+        "form" not in page_content
+        and page_content.get("title") == CONFIRM_EMAIL_PAGE_TITLE
+    ):
         # Refresh the confirm email page whenever the user brings the popup
         # back into focus. This is not strictly necessary since deposit.html
         # and withdraw.html have 'Refresh' buttons, but this is a better UX.

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -35,7 +35,7 @@ from polaris.integrations.forms import TransactionForm
 from polaris.locale.views import validate_language, activate_lang_for_request
 from polaris.integrations import (
     registered_deposit_integration as rdi,
-    registered_javascript_func,
+    registered_scripts_func,
     registered_fee_func,
 )
 
@@ -206,6 +206,8 @@ def get_interactive_deposit(request: Request) -> Response:
             content_type="text/html",
         )
 
+    scripts = registered_scripts_func(content)
+
     if content.get("form"):
         form_class = content.pop("form")
         if issubclass(form_class, TransactionForm) and amount:
@@ -221,9 +223,7 @@ def get_interactive_deposit(request: Request) -> Response:
 
     post_url = f"{reverse('post_interactive_deposit')}?{urlencode(url_args)}"
     get_url = f"{reverse('get_interactive_deposit')}?{urlencode(url_args)}"
-    content.update(
-        post_url=post_url, get_url=get_url, scripts=registered_javascript_func()
-    )
+    content.update(post_url=post_url, get_url=get_url, scripts=scripts)
 
     return Response(content, template_name="deposit/form.html")
 

--- a/polaris/polaris/integrations/__init__.py
+++ b/polaris/polaris/integrations/__init__.py
@@ -3,7 +3,7 @@ from typing import Callable
 from polaris.integrations.fees import calculate_fee, registered_fee_func
 from polaris.integrations.forms import TransactionForm, CreditCardForm
 from polaris.integrations.toml import get_stellar_toml, registered_toml_func
-from polaris.integrations.javascript import scripts, registered_javascript_func
+from polaris.integrations.javascript import scripts, registered_scripts_func
 from polaris.integrations.transactions import (
     DepositIntegration,
     WithdrawalIntegration,
@@ -16,7 +16,7 @@ def register_integrations(
     deposit: DepositIntegration = None,
     withdrawal: WithdrawalIntegration = None,
     toml_func: Callable = None,
-    javascript_func: Callable = None,
+    scripts_func: Callable = None,
     fee_func: Callable = None,
 ):
     """
@@ -55,7 +55,7 @@ def register_integrations(
     :param withdrawal: the :class:`WithdrawalIntegration` subclass instance to
         be used by Polaris
     :param toml_func: a function that returns stellar.toml data as a dictionary
-    :param javascript_func: a function that returns a list of script tags as
+    :param scripts_func: a function that returns a list of script tags as
         strings
     :param fee_func: a function that returns the fee that would be charged
     :raises ValueError: missing argument(s)
@@ -72,7 +72,7 @@ def register_integrations(
         raise TypeError("withdrawal must be a subclass of WithdrawalIntegration")
     elif toml_func and not callable(toml_func):
         raise TypeError("toml_func is not callable")
-    elif javascript_func and not callable(javascript_func):
+    elif scripts_func and not callable(scripts_func):
         raise TypeError("javascript_func is not callable")
     elif fee_func and not callable(fee_func):
         raise TypeError("javascript_func is not callable")
@@ -81,7 +81,7 @@ def register_integrations(
         (deposit, "registered_deposit_integration"),
         (withdrawal, "registered_withdrawal_integration"),
         (toml_func, "registered_toml_func"),
-        (javascript_func, "registered_javascript_func"),
+        (scripts_func, "registered_scripts_func"),
         (fee_func, "registered_fee_func"),
     ]:
         if obj:

--- a/polaris/polaris/integrations/javascript.py
+++ b/polaris/polaris/integrations/javascript.py
@@ -1,21 +1,28 @@
-from typing import List
+from typing import List, Dict, Optional
 
 
-def scripts() -> List[str]:
+def scripts(page_content: Optional[Dict]) -> List[str]:
     """
     .. _`example reference server`: https://github.com/stellar/django-polaris/tree/master/example
 
-    Return a list of strings containing script tags that will be rendered at
-    the bottom of every HTML body rendered by the server like so:
+    Return a list of strings containing script tags that will be added to the
+    bottom of the HTML body served for the current request. The scripts
+    will be rendered like so:
     ::
 
         {% for script in scripts %}
             {{ script|safe }}
         {% endfor %}
 
+    `page_content` will be the return value from ``content_for_transaction()``
+    for requests during the interactive flow and ``None`` for requests to the
+    `/more_info` endpoint. Anchors can
+    use `page_content` to determine which scripts need to be rendered.
+
     This gives anchors a great deal of freedom on the client side. The
     `example reference server`_ uses this functionality to inject Google
-    Analytics into our deployment of Polaris.
+    Analytics into our deployment of Polaris, and to refresh the Confirm Email
+    page every time the window is brought back into focus.
 
     Replace this function with another by passing it to
     :func:`polaris.integrations.register_integrations` like so:
@@ -39,4 +46,4 @@ def scripts() -> List[str]:
     return []
 
 
-registered_javascript_func = scripts
+registered_scripts_func = scripts

--- a/polaris/polaris/transaction/views.py
+++ b/polaris/polaris/transaction/views.py
@@ -17,7 +17,7 @@ from polaris.models import Transaction
 from polaris.transaction.serializers import TransactionSerializer
 from polaris.integrations import (
     registered_deposit_integration as rdi,
-    registered_javascript_func,
+    registered_scripts_func,
 )
 
 
@@ -89,7 +89,7 @@ def more_info(request: Request) -> Response:
         "tx_json": tx_json,
         "transaction": request_transaction,
         "asset_code": request_transaction.asset.code,
-        "scripts": registered_javascript_func(),
+        "scripts": registered_scripts_func(None),
     }
 
     callback = request.GET.get("callback")

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -23,7 +23,6 @@ from polaris.helpers import (
     authenticate_session,
     invalidate_session,
     interactive_args_validation,
-    check_middleware,
     Logger,
     interactive_url,
 )
@@ -32,7 +31,7 @@ from polaris.integrations.forms import TransactionForm
 from polaris.locale.views import validate_language, activate_lang_for_request
 from polaris.integrations import (
     registered_withdrawal_integration as rwi,
-    registered_javascript_func,
+    registered_scripts_func,
     registered_fee_func,
 )
 
@@ -203,6 +202,8 @@ def get_interactive_withdraw(request: Request) -> Response:
             content_type="text/html",
         )
 
+    scripts = registered_scripts_func(content)
+
     if content.get("form"):
         form_class = content.pop("form")
         if issubclass(form_class, TransactionForm) and amount:
@@ -218,9 +219,7 @@ def get_interactive_withdraw(request: Request) -> Response:
 
     post_url = f"{reverse('post_interactive_withdraw')}?{urlencode(url_args)}"
     get_url = f"{reverse('get_interactive_withdraw')}?{urlencode(url_args)}"
-    content.update(
-        post_url=post_url, get_url=get_url, scripts=registered_javascript_func()
-    )
+    content.update(post_url=post_url, get_url=get_url, scripts=scripts)
 
     return Response(content, template_name="withdraw/form.html")
 


### PR DESCRIPTION
resolves stellar/django-polaris#134 

Also changes `registered_javascript_func` to `registered_scripts_func` and the `register_integrations()` `javascript_func` parameter to `scripts_func`.