### PR TITLE
Allow anchor to pass form parameters for initialization

### DIFF
--- a/example/server/integrations.py
+++ b/example/server/integrations.py
@@ -109,7 +109,7 @@ def check_kyc(transaction: Transaction) -> Optional[Dict]:
     ).first()
     if not account:  # Unknown stellar account, get KYC info
         return {
-            "form": KYCForm,
+            "form": (KYCForm, {}),
             "icon_label": _("Stellar Development Foundation"),
             "title": _("Polaris KYC Information"),
             "guidance": (

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -230,8 +230,7 @@ def get_interactive_deposit(request: Request) -> Response:
             )
         is_transaction_form = issubclass(form_class, TransactionForm)
         if is_transaction_form:
-            field_args = dict(request.POST.items(), amount=amount)
-            content["form"] = form_class(asset, field_args, **form_args)
+            content["form"] = form_class(asset, {"amount": amount}, **form_args)
         else:
             content["form"] = form_class(request.POST, **form_args)
 

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -137,7 +137,7 @@ def post_interactive_deposit(request: Request) -> Response:
 
     else:
         content.update(form=form)
-        return Response(content, template_name="deposit/form.html", status=400)
+        return Response(content, template_name="deposit/form.html", status=422)
 
 
 @api_view(["GET"])

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -230,9 +230,9 @@ def get_interactive_deposit(request: Request) -> Response:
             )
         is_transaction_form = issubclass(form_class, TransactionForm)
         if is_transaction_form:
-            content["form"] = form_class(asset, {"amount": amount}, **form_args)
+            content["form"] = form_class(asset, initial={"amount": amount}, **form_args)
         else:
-            content["form"] = form_class(request.POST, **form_args)
+            content["form"] = form_class(**form_args)
 
     url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
     if callback:

--- a/polaris/polaris/helpers.py
+++ b/polaris/polaris/helpers.py
@@ -284,7 +284,7 @@ def interactive_args_validation(request: Request) -> Dict:
             return dict(error=render_error_response("invalid 'amount'"))
 
         err_resp = verify_valid_asset_operation(
-            asset, amount, Transaction.kind, content_type="text/html"
+            asset, amount, transaction.kind, content_type="text/html"
         )
         if err_resp:
             return dict(error=err_resp)

--- a/polaris/polaris/integrations/forms.py
+++ b/polaris/polaris/integrations/forms.py
@@ -2,6 +2,8 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.forms.widgets import TextInput
 
+from polaris.models import Asset
+
 
 class CardNumberInput(TextInput):
     template_name = "widgets/card_number.html"
@@ -94,6 +96,10 @@ class TransactionForm(forms.Form):
     which ensures the amount is within the bounds for the asset type.
     """
 
+    def __init__(self, asset: Asset, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.asset = asset
+
     amount = forms.DecimalField(
         min_value=0,
         widget=forms.NumberInput(attrs={"class": "input", "test-value": "100"}),
@@ -102,7 +108,6 @@ class TransactionForm(forms.Form):
         label=_("Amount"),
         localize=True,
     )
-    asset = None
 
     def clean_amount(self):
         """Validate the provided amount of an asset."""

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -111,9 +111,11 @@ class DepositIntegration:
                 else:
                     content["form"] = form_class(**form_args)
 
-        Make sure you ``pop()`` any keyword arguments passed to the form before
-        calling ``super().__init__(*args, **kwargs)``, since django's Form class
-        does not accept extra keyword arguments.
+        In your form's ``__init__()`, make sure you ``pop()`` any keyword arguments
+        passed to the form before calling ``super().__init__(*args, **kwargs)``,
+        since django's Form class does not accept extra keyword arguments. If you
+        don't use keyword arguments, you don't need to define an ``__init__()``
+        function.
 
         After a form is submitted and validated, Polaris will call
         :func:`DepositlIntegration.after_form_validation` with the populated

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -76,7 +76,7 @@ class DepositIntegration:
         to render for the user given the state of the interactive flow.
 
         For example, this function should return a :class:`TransactionForm`
-        along with any keyword parameters to use during initialization to get
+        along with any keyword arguments to use during initialization to get
         the get the amount that should be transferred. Once the form is
         submitted, Polaris will detect the form used is a
         :class:`TransactionForm` subclass and update the ``amount_in`` column
@@ -90,7 +90,7 @@ class DepositIntegration:
             def content_for_transaction(cls, transaction):
                 ...
                 return {
-                    "form": (TransactionForm, {"arg1": "val1"}),
+                    "form": (TransactionForm, {}),
                     "title": "Deposit Transaction Form",
                     "guidance": "Please enter the amount you would like to deposit.",
                     "icon_label": "Stellar Development Foundation"
@@ -98,6 +98,22 @@ class DepositIntegration:
 
         The icon image displayed can be replaced by adding a ``company-icon.svg``
         in the top level of your app's static files directory.
+
+        The form returned will be initialized like so:
+        ::
+
+            if content.get("form"):
+                form_class, form_args = content.get("form")
+                is_transaction_form = issubclass(form_class, TransactionForm)
+                if is_transaction_form:
+                    # amount can be prepopulated in the TransactionForm
+                    content["form"] = form_class(asset, initial={"amount": amount}, **form_args)
+                else:
+                    content["form"] = form_class(**form_args)
+
+        Make sure you ``pop()`` any keyword arguments passed to the form before
+        calling ``super().__init__(*args, **kwargs)``, since django's Form class
+        does not accept extra keyword arguments.
 
         After a form is submitted and validated, Polaris will call
         :func:`DepositlIntegration.after_form_validation` with the populated

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -75,10 +75,12 @@ class DepositIntegration:
         This function should return a dictionary containing the next form class
         to render for the user given the state of the interactive flow.
 
-        For example, this function should return a :class:`TransactionForm` to
-        get the amount that should be transferred. Once the form is submitted,
-        Polaris will detect the form used is a :class:`TransactionForm` subclass
-        and update the ``amount_in`` column with the amount specified in form.
+        For example, this function should return a :class:`TransactionForm`
+        along with any keyword parameters to use during initialization to get
+        the get the amount that should be transferred. Once the form is
+        submitted, Polaris will detect the form used is a
+        :class:`TransactionForm` subclass and update the ``amount_in`` column
+        with the amount specified in form.
 
         The form will be rendered inside a django template that has several
         pieces of content that can be replaced by returning a dictionary
@@ -88,7 +90,7 @@ class DepositIntegration:
             def content_for_transaction(cls, transaction):
                 ...
                 return {
-                    "form": TransactionForm,
+                    "form": (TransactionForm, {"arg1": "val1"}),
                     "title": "Deposit Transaction Form",
                     "guidance": "Please enter the amount you would like to deposit.",
                     "icon_label": "Stellar Development Foundation"
@@ -124,16 +126,15 @@ class DepositIntegration:
         ultimately marking the transaction as ``complete`` upon success.
 
         :param transaction: the :class:`Transaction` database object
-        :return: an uninitialized :class:`forms.Form` subclass. For transaction
-            information, return a :class:`polaris.integrations.TransactionForm`
-            subclass.
+        :return: a dictionary containing various pieces of information to use
+            when rendering the next page.
         """
         if transaction.amount_in:
             # we've collected transaction info
             # and don't implement KYC by default
             return
 
-        return {"form": TransactionForm}
+        return {"form": (TransactionForm, {})}
 
     @classmethod
     def after_form_validation(cls, form: forms.Form, transaction: Transaction):
@@ -230,15 +231,15 @@ class WithdrawalIntegration:
         Same as :func:`DepositIntegration.content_for_transaction`
 
         :param transaction: the :class:`Transaction` database object
-        :return: an uninitialized :class:`forms.Form` subclass. For transaction
-            information, use a :class:`TransactionForm` subclass.
+        :return: a dictionary containing various pieces of information to use
+            when rendering the next page.
         """
         if transaction.amount_in:
             # we've collected transaction info
             # and don't implement KYC by default
             return
 
-        return {"form": WithdrawForm}
+        return {"form": (WithdrawForm, {})}
 
     @classmethod
     def after_form_validation(cls, form: TransactionForm, transaction: Transaction):

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -111,7 +111,7 @@ class DepositIntegration:
                 else:
                     content["form"] = form_class(**form_args)
 
-        In your form's ``__init__()`, make sure you ``pop()`` any keyword arguments
+        In your form's ``__init__()``, make sure you ``pop()`` any keyword arguments
         passed to the form before calling ``super().__init__(*args, **kwargs)``,
         since django's Form class does not accept extra keyword arguments. If you
         don't use keyword arguments, you don't need to define an ``__init__()``

--- a/polaris/polaris/locale/pt/LC_MESSAGES/django.po
+++ b/polaris/polaris/locale/pt/LC_MESSAGES/django.po
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: deposit/views.py:56 deposit/views.py:130 withdraw/views.py:48
-msgid "The anchor did not provide form content, unable to serve page."
+msgid "The anchor did not provide content, unable to serve page."
 msgstr "A âncora não retornou um conteúdo, não é possível mostrar a página."
 
 #: deposit/views.py:105 withdraw/views.py:96

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -228,7 +228,7 @@ def get_interactive_withdraw(request: Request) -> Response:
             )
         is_transaction_form = issubclass(form_class, TransactionForm)
         if is_transaction_form:
-            content["form"] = form_class(asset, {"amount": amount}, **form_args)
+            content["form"] = form_class(asset, initial={"amount": amount}, **form_args)
         else:
             content["form"] = form_class(**form_args)
 

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -134,7 +134,7 @@ def post_interactive_withdraw(request: Request) -> Response:
 
     else:
         content.update(form=form)
-        return Response(content, template_name="withdraw/form.html", status=400)
+        return Response(content, template_name="withdraw/form.html", status=422)
 
 
 @api_view(["GET"])

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -95,10 +95,11 @@ def post_interactive_withdraw(request: Request) -> Response:
             content_type="text/html",
         )
 
-    form = form_class({**form_args, **dict(request.POST.items())})
     is_transaction_form = issubclass(form_class, TransactionForm)
     if is_transaction_form:
-        form.asset = asset
+        form = form_class(asset, request.POST, **form_args)
+    else:
+        form = form_class(request.POST, **form_args)
 
     if form.is_valid():
         if is_transaction_form:
@@ -215,7 +216,7 @@ def get_interactive_withdraw(request: Request) -> Response:
 
     if content.get("form"):
         try:
-            form_class, args = content.get("form")
+            form_class, form_args = content.get("form")
         except TypeError:
             logger.exception(
                 "content_for_transaction(): 'form' key value must be a tuple"
@@ -225,10 +226,12 @@ def get_interactive_withdraw(request: Request) -> Response:
                 status_code=500,
                 content_type="text/html",
             )
-        if issubclass(form_class, TransactionForm) and amount:
-            content["form"] = form_class({"amount": amount, **args})
+        is_transaction_form = issubclass(form_class, TransactionForm)
+        if is_transaction_form:
+            field_args = dict(request.POST.items(), amount=amount)
+            content["form"] = form_class(asset, field_args, **form_args)
         else:
-            content["form"] = form_class(**args)
+            content["form"] = form_class(request.POST, **form_args)
 
     url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
     if callback:

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -228,10 +228,9 @@ def get_interactive_withdraw(request: Request) -> Response:
             )
         is_transaction_form = issubclass(form_class, TransactionForm)
         if is_transaction_form:
-            field_args = dict(request.POST.items(), amount=amount)
-            content["form"] = form_class(asset, field_args, **form_args)
+            content["form"] = form_class(asset, {"amount": amount}, **form_args)
         else:
-            content["form"] = form_class(request.POST, **form_args)
+            content["form"] = form_class(**form_args)
 
     url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
     if callback:

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -80,7 +80,7 @@ def post_interactive_withdraw(request: Request) -> Response:
             f"for {transaction.id}"
         )
         return render_error_response(
-            _("The anchor did not provide a content, unable to serve page."),
+            _("The anchor did not provide content, unable to serve page."),
             status_code=500,
             content_type="text/html",
         )
@@ -204,9 +204,9 @@ def get_interactive_withdraw(request: Request) -> Response:
 
     content = rwi.content_for_transaction(transaction)
     if not content:
-        logger.error("The anchor did not provide a form, unable to serve page.")
+        logger.error("The anchor did not provide content, unable to serve page.")
         return render_error_response(
-            _("The anchor did not provide a form, unable to serve page."),
+            _("The anchor did not provide content, unable to serve page."),
             status_code=500,
             content_type="text/html",
         )


### PR DESCRIPTION
resolves stellar/django-polaris#150 

nTokens needs to be able to pass their own parameters to the forms served to users during initialization, and this was not previously possible since Polaris initialized the form with URL or POST arguments.

With this change, `content_for_transaction()`'s `form` key value changes from a `forms.Form` class to a tuple containing the form class as well as a dict containing any keyword arguments the anchor wants to use during initialization.

@ronaldoy for reference