### PR TITLE
Fix new TRANSFER_SERVER_SEP0024 field

### DIFF
--- a/polaris/polaris/stellartoml/views.py
+++ b/polaris/polaris/stellartoml/views.py
@@ -17,7 +17,7 @@ def generate_toml(request):
     """Generate the TOML file."""
     toml_dict = {
         "TRANSFER_SERVER": settings.HOST_URL,
-        "TRANSFER_SERVER_0024": settings.HOST_URL,
+        "TRANSFER_SERVER_SEP0024": settings.HOST_URL,
         "WEB_AUTH_ENDPOINT": os.path.join(settings.HOST_URL, "auth"),
         "ACCOUNTS": [
             asset["DISTRIBUTION_ACCOUNT_ADDRESS"] for asset in settings.ASSETS.values()


### PR DESCRIPTION
The sep24 spec states we need a field called TRANSFER_SERVER_SEP0024 but we have TRANSFER_SERVER_0024, this updates that field name

https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#prerequisites