### PR TITLE
return 422 on extra and unprocessable requests

### DIFF
--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -82,6 +82,14 @@ def post_interactive_deposit(request: Request) -> Response:
             "Initial content_for_transaction() call returned None in "
             f"POST request for transaction: {transaction.id}"
         )
+        if transaction.status != transaction.STATUS.incomplete:
+            return render_error_response(
+                _(
+                    "The anchor did not provide content, is the interactive flow already complete?"
+                ),
+                status_code=422,
+                content_type="text/html",
+            )
         return render_error_response(
             _("The anchor did not provide form content, unable to serve page."),
             status_code=500,
@@ -209,6 +217,14 @@ def get_interactive_deposit(request: Request) -> Response:
     content = rdi.content_for_transaction(transaction)
     if not content:
         logger.error("The anchor did not provide content, unable to serve page.")
+        if transaction.status != transaction.STATUS.incomplete:
+            return render_error_response(
+                _(
+                    "The anchor did not provide content, is the interactive flow already complete?"
+                ),
+                status_code=422,
+                content_type="text/html",
+            )
         return render_error_response(
             _("The anchor did not provide content, unable to serve page."),
             status_code=500,

--- a/polaris/polaris/locale/pt/LC_MESSAGES/django.po
+++ b/polaris/polaris/locale/pt/LC_MESSAGES/django.po
@@ -284,5 +284,5 @@ msgid "$"
 msgstr "R$"
 
 msgid "The anchor did not provide content, is the interactive flow already complete?"
-msgid ""
+msgid "A âncora não forneceu conteúdo, o fluxo interativo já está completo?"
 

--- a/polaris/polaris/locale/pt/LC_MESSAGES/django.po
+++ b/polaris/polaris/locale/pt/LC_MESSAGES/django.po
@@ -282,3 +282,7 @@ msgstr "erro"
 
 msgid "$"
 msgstr "R$"
+
+msgid "The anchor did not provide content, is the interactive flow already complete?"
+msgid ""
+

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -79,6 +79,14 @@ def post_interactive_withdraw(request: Request) -> Response:
             "Initial content_for_transaction() call returned None "
             f"for {transaction.id}"
         )
+        if transaction.status != transaction.STATUS.incomplete:
+            return render_error_response(
+                _(
+                    "The anchor did not provide content, is the interactive flow already complete?"
+                ),
+                status_code=422,
+                content_type="text/html",
+            )
         return render_error_response(
             _("The anchor did not provide content, unable to serve page."),
             status_code=500,
@@ -206,6 +214,14 @@ def get_interactive_withdraw(request: Request) -> Response:
     content = rwi.content_for_transaction(transaction)
     if not content:
         logger.error("The anchor did not provide content, unable to serve page.")
+        if transaction.status != transaction.STATUS.incomplete:
+            return render_error_response(
+                _(
+                    "The anchor did not provide content, is the interactive flow already complete?"
+                ),
+                status_code=422,
+                content_type="text/html",
+            )
         return render_error_response(
             _("The anchor did not provide content, unable to serve page."),
             status_code=500,


### PR DESCRIPTION
resolves #170 

*not ready to be merged, but ready for review*

Returns 422 when the anchor doesn't return content for the interactive flow response AND the transaction is not in `incomplete` status.

@vitchor Can you send me the translation for the error message added?