### PR TITLE
Add numeric keypad for amount field

### DIFF
--- a/polaris/polaris/integrations/forms.py
+++ b/polaris/polaris/integrations/forms.py
@@ -107,7 +107,7 @@ class TransactionForm(forms.Form):
 
     amount = forms.DecimalField(
         min_value=0,
-        widget=forms.NumberInput(attrs={"class": "input"}),
+        widget=forms.NumberInput(attrs={"class": "input", "inputmode":"decimal"}),
         max_digits=30,
         decimal_places=7,
         label=_("Amount"),


### PR DESCRIPTION
Currently the keypad in iOS shows small numbers with some special characters. This commit changes to a keypad with large numbers, improving user experience on mobile devices. 