### PR TITLE
SEP-9 Support

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -41,7 +41,7 @@ The functions below facilitate the process of collecting the information needed.
 
 .. autofunction:: polaris.integrations.WithdrawalIntegration.after_form_validation
 
-Some wallets may pass fields documented in SEP-9_ to the `/interactive` endpoints for
+Some wallets may pass fields documented in SEP-9_ in the initial POST request for
 the anchor to use to pre-populate the forms presented to the user. Polaris provides
 an integration function to save and validate the fields passed.
 

--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -18,6 +18,7 @@ implemented. See the `Registering Integrations`_ section for more information.
 Form Integrations
 -----------------
 
+.. _SEP-9: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md
 .. _Django Forms: https://docs.djangoproject.com/en/2.2/topics/forms/#forms-in-django
 
 Polaris provides a set of integration functions that allow you to collect,
@@ -39,6 +40,14 @@ The functions below facilitate the process of collecting the information needed.
 .. autofunction:: polaris.integrations.WithdrawalIntegration.content_for_transaction
 
 .. autofunction:: polaris.integrations.WithdrawalIntegration.after_form_validation
+
+Some wallets may pass fields documented in SEP-9_ to the `/interactive` endpoints for
+the anchor to use to pre-populate the forms presented to the user. Polaris provides
+an integration function to save and validate the fields passed.
+
+.. autofunction:: polaris.integrations.DepositIntegration.save_sep9_fields
+
+.. autofunction:: polaris.integrations.WithdrawalIntegration.save_sep9_fields
 
 Use an External Application for the Interactive Flow
 ----------------------------------------------------

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -277,7 +277,7 @@ def deposit(account: str, request: Request) -> Response:
         return render_error_response(_("invalid 'account'"))
 
     try:
-        rdi.save_sep9_fields(sep9_fields, lang)
+        rdi.save_sep9_fields(stellar_account, sep9_fields, lang)
     except ValueError as e:
         # The anchor found a validation error in the sep-9 fields POSTed by
         # the wallet. The error string returned should be in the language

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -28,6 +28,7 @@ from polaris.helpers import (
     interactive_args_validation,
     Logger,
     interactive_url,
+    extract_sep9_fields,
 )
 from polaris.models import Asset, Transaction
 from polaris.integrations.forms import TransactionForm
@@ -250,6 +251,7 @@ def deposit(account: str, request: Request) -> Response:
     asset_code = request.POST.get("asset_code")
     stellar_account = request.POST.get("account")
     lang = request.POST.get("lang")
+    sep9_fields = extract_sep9_fields(request.POST)
     if lang:
         err_resp = validate_language(lang)
         if err_resp:
@@ -273,6 +275,14 @@ def deposit(account: str, request: Request) -> Response:
         Keypair.from_public_key(stellar_account)
     except Ed25519PublicKeyInvalidError:
         return render_error_response(_("invalid 'account'"))
+
+    try:
+        rdi.save_sep9_fields(sep9_fields, lang)
+    except ValueError as e:
+        # The anchor found a validation error in the sep-9 fields POSTed by
+        # the wallet. The error string returned should be in the language
+        # specified in the request.
+        return render_error_response(str(e))
 
     # Construct interactive deposit pop-up URL.
     transaction_id = create_transaction_id()

--- a/polaris/polaris/helpers.py
+++ b/polaris/polaris/helpers.py
@@ -372,6 +372,67 @@ def verify_valid_asset_operation(
         )
 
 
+SEP_9_FIELDS = {
+    "family_name",
+    "last_name",
+    "given_name",
+    "first_name",
+    "additional_name",
+    "address_country_code",
+    "state_or_province",
+    "city",
+    "postal_code",
+    "address",
+    "mobile_number",
+    "email_address",
+    "birth_date",
+    "birth_place",
+    "birth_country_code",
+    "bank_account_number",
+    "bank_number",
+    "bank_phone_number",
+    "tax_id",
+    "tax_id_name",
+    "occupation",
+    "employer_name",
+    "employer_address",
+    "language_code",
+    "id_type",
+    "id_country_code",
+    "id_issue_date",
+    "id_expiration_date",
+    "id_number",
+    "photo_id_front",
+    "photo_id_back",
+    "notary_approval_of_photo_id",
+    "ip_address",
+    "photo_proof_residence",
+    "organization.name",
+    "organization.VAT_number",
+    "organization.registration_number",
+    "organization.registered_address",
+    "organization.number_of_shareholders",
+    "organization.shareholder_name",
+    "organization.photo_incorporation_doc",
+    "organization.photo_proof_adress",
+    "organization.address_country_code",
+    "organization.state_or_province",
+    "organization.city",
+    "organization.postal_code",
+    "organization.director_name",
+    "organization.website",
+    "organization.email",
+    "organization.phone",
+}
+
+
+def extract_sep9_fields(args):
+    sep9_args = {}
+    for field in SEP_9_FIELDS:
+        sep9_args[field] = args.get(field)
+    return sep9_args
+
+
 class Logger:
     """
     Additional log message pre-processing.

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -215,18 +215,18 @@ class DepositIntegration:
         return None
 
     @classmethod
-    def save_sep9_fields(
-        cls, transaction: Transaction, fields: Dict, language_code: str
-    ):
+    def save_sep9_fields(cls, stellar_account: str, fields: Dict, language_code: str):
         """
         Save the `fields` passed for `transaction` to pre-populate the forms returned
-        from ``content_for_transaction()``.
+        from ``content_for_transaction()``. Note that this function is called before
+        the transaction is created.
 
-        For example, save the user's contact information with the model used for KYC information.
+        For example, you could save the user's contact information with the model used
+        for KYC information.
         ::
 
             # Assuming you have a similar method and model
-            user = user_for_transaction(transaction)
+            user = user_for_account(stellar_account)
             user.phone_number = fields.get('mobile_number')
             user.email = fields.get('email_address')
             user.save()
@@ -236,7 +236,7 @@ class DepositIntegration:
         ::
 
             # In your content_for_transaction() implementation
-            user = user_for_transaction(transaction)
+            user = user_for_account(transaction.stellar_account)
             form_args = {
                 'phone_number': format_number(user.phone_number),
                 'email': user.email_address
@@ -347,9 +347,7 @@ class WithdrawalIntegration:
         return None
 
     @classmethod
-    def save_sep9_fields(
-        cls, transaction: Transaction, fields: Dict, language_code: str
-    ):
+    def save_sep9_fields(cls, stellar_account: str, fields: Dict, language_code: str):
         """
         Same as ``DepositIntegration.save_sep9_fields``
         """

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -214,6 +214,45 @@ class DepositIntegration:
         """
         return None
 
+    @classmethod
+    def save_sep9_fields(
+        cls, transaction: Transaction, fields: Dict, language_code: str
+    ):
+        """
+        Save the `fields` passed for `transaction` to pre-populate the forms returned
+        from ``content_for_transaction()``.
+
+        For example, save the user's contact information with the model used for KYC information.
+        ::
+
+            # Assuming you have a similar method and model
+            user = user_for_transaction(transaction)
+            user.phone_number = fields.get('mobile_number')
+            user.email = fields.get('email_address')
+            user.save()
+
+        Then when returning a form to collect KYC information, also return the values
+        saved in this method relevant to that form.
+        ::
+
+            # In your content_for_transaction() implementation
+            user = user_for_transaction(transaction)
+            form_args = {
+                'phone_number': format_number(user.phone_number),
+                'email': user.email_address
+            }
+            return {
+                'form': (KYCForm, form_args),
+                'title': "KYC Collection"
+            }
+
+        If you'd like to validate the values passed in `fields`, you can perform any necessary
+        checks and raise a ``ValueError`` in this function. Polaris will return the message of
+        the exception in the response along with 400 HTTP status. The error message should be
+        in the language specified by `language_code` if possible.
+        """
+        pass
+
 
 class WithdrawalIntegration:
     """
@@ -306,6 +345,15 @@ class WithdrawalIntegration:
             withdraw flow
         """
         return None
+
+    @classmethod
+    def save_sep9_fields(
+        cls, transaction: Transaction, fields: Dict, language_code: str
+    ):
+        """
+        Same as ``DepositIntegration.save_sep9_fields``
+        """
+        pass
 
 
 registered_deposit_integration = DepositIntegration()

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -217,7 +217,7 @@ class DepositIntegration:
     @classmethod
     def save_sep9_fields(cls, stellar_account: str, fields: Dict, language_code: str):
         """
-        Save the `fields` passed for `transaction` to pre-populate the forms returned
+        Save the `fields` passed for `stellar_account` to pre-populate the forms returned
         from ``content_for_transaction()``. Note that this function is called before
         the transaction is created.
 
@@ -242,7 +242,7 @@ class DepositIntegration:
                 'email': user.email_address
             }
             return {
-                'form': (KYCForm, form_args),
+                'form': KYCForm(initial=form_args),
                 'title': "KYC Collection"
             }
 

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -266,7 +266,7 @@ def withdraw(account: str, request: Request) -> Response:
     distribution_address = settings.ASSETS[asset.code]["DISTRIBUTION_ACCOUNT_ADDRESS"]
 
     try:
-        rwi.save_sep9_fields(sep9_fields, lang)
+        rwi.save_sep9_fields(account, sep9_fields, lang)
     except ValueError as e:
         # The anchor found a validation error in the sep-9 fields POSTed by
         # the wallet. The error string returned should be in the language


### PR DESCRIPTION
resolves #164 

Added an integration point for anchors to save the SEP-9 fields passed to the `/interactive` endpoints by wallets. 

The anchors are expected to save this information in a model they've defined. Then, for each form requested during the interactive flow, the anchor should return the necessary fields related to the form also returned.