### PR TITLE
Changed content_for_transaction API

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -25,7 +25,7 @@ validate, and process the information you need to collect from users with
 `Django Forms`_.
 
 Of course, you'll need to collect the amount the user would like to deposit
-or withdraw. Polaris provides a :class:`TransactionForm` that can be subclassed to
+or withdraw. Polaris provides a ``TransactionForm`` that can be subclassed to
 add additional fields for this purpose. One ``TransactionForm`` should be rendered
 for every transaction processed. See the :doc:`../forms/index` documentation for
 more information.

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -199,7 +199,7 @@ def get_interactive_deposit(request: Request) -> Response:
     if url:  # The anchor uses a standalone interactive flow
         return redirect(url)
 
-    content = rdi.content_for_transaction(transaction, prefill_data={"amount": amount})
+    content = rdi.content_for_transaction(transaction, amount=amount)
     if not content:
         logger.error("The anchor did not provide content, unable to serve page.")
         if transaction.status != transaction.STATUS.incomplete:

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -180,9 +180,7 @@ def get_interactive_deposit(request: Request) -> Response:
            cookie should still be included in the response so future calls to
            GET /transactions/deposit/interactive/complete are authenticated.
         3. content_for_transaction() is called to retrieve the next form to
-           render to the user. `amount` is prepopulated in the form if it was
-           passed as a parameter to this endpoint and the form is a subclass
-           of TransactionForm.
+           render to the user.
         4. get and post URLs are constructed with the appropriate arguments
            and passed to the response to be rendered to the user.
     """

--- a/polaris/polaris/deposit/views.py
+++ b/polaris/polaris/deposit/views.py
@@ -97,6 +97,14 @@ def post_interactive_deposit(request: Request) -> Response:
         )
 
     form = content.get("form")
+    if not form.is_bound:
+        # The anchor must initialize the form with the request.POST data
+        return render_error_response(
+            _("Unable to validate form submission."),
+            status_code=500,
+            content_type="text/html",
+        )
+
     if form.is_valid():
         if issubclass(form.__class__, TransactionForm):
             fee_params = {

--- a/polaris/polaris/integrations/__init__.py
+++ b/polaris/polaris/integrations/__init__.py
@@ -21,8 +21,8 @@ def register_integrations(
 ):
     """
     Registers instances of user-defined subclasses of
-    :class:`.WithdrawalIntegration` and
-    :class:`.DepositIntegration` with Polaris.
+    ``WithdrawalIntegration`` and
+    ``DepositIntegration`` with Polaris.
 
     Call this function in the relevant Django AppConfig.ready() function:
     ::
@@ -50,9 +50,9 @@ def register_integrations(
 
     See the integration classes for more information on implementation.
 
-    :param deposit: the :class:`.DepositIntegration` subclass instance to be
+    :param deposit: the ``DepositIntegration`` subclass instance to be
         used by Polaris
-    :param withdrawal: the :class:`WithdrawalIntegration` subclass instance to
+    :param withdrawal: the ``WithdrawalIntegration`` subclass instance to
         be used by Polaris
     :param toml_func: a function that returns stellar.toml data as a dictionary
     :param scripts_func: a function that returns a list of script tags as

--- a/polaris/polaris/integrations/fees.py
+++ b/polaris/polaris/integrations/fees.py
@@ -22,7 +22,7 @@ def calculate_fee(fee_params: Dict) -> Decimal:
     use the fields collected via their TransactionForm in fee calculation.
 
     Replace this function by registering another through
-    :func:`register_integrations`:
+    ``register_integrations``:
     ::
 
         from myapp.integrations import (

--- a/polaris/polaris/integrations/javascript.py
+++ b/polaris/polaris/integrations/javascript.py
@@ -25,7 +25,7 @@ def scripts(page_content: Optional[Dict]) -> List[str]:
     page every time the window is brought back into focus.
 
     Replace this function with another by passing it to
-    :func:`polaris.integrations.register_integrations` like so:
+    ``polaris.integrations.register_integrations`` like so:
     ::
 
         from myapp.integrations import (

--- a/polaris/polaris/integrations/javascript.py
+++ b/polaris/polaris/integrations/javascript.py
@@ -37,7 +37,7 @@ def scripts(page_content: Optional[Dict]) -> List[str]:
         register_integrations(
             deposit=MyDepositIntegration(),
             withdrawal=MyWithdrawalIntegration(),
-            javascript_func=scripts
+            scripts_func=scripts
         )
 
     Note that the scripts will be executed in the order in which they are

--- a/polaris/polaris/integrations/toml.py
+++ b/polaris/polaris/integrations/toml.py
@@ -9,7 +9,7 @@ def get_stellar_toml():
 
     Returns the default info for stellar.toml as a dictionary. Replace this
     function with another by passing it to
-    :func:`polaris.integrations.register_integrations` like so:
+    ``polaris.integrations.register_integrations`` like so:
     ::
 
         from myapp.integrations import (

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from django.db.models import QuerySet
 from django import forms
+from django.http import QueryDict
 from rest_framework.request import Request
 
 from polaris.models import Transaction, Asset
@@ -69,7 +70,12 @@ class DepositIntegration:
         pass
 
     @classmethod
-    def content_for_transaction(cls, transaction: Transaction) -> Optional[Dict]:
+    def content_for_transaction(
+        cls,
+        transaction: Transaction,
+        post_data: Optional[QueryDict] = None,
+        prefill_data: Optional[Dict] = None,
+    ) -> Optional[Dict]:
         """
         This function should return a dictionary containing the next form class
         to render for the user given the state of the interactive flow.
@@ -151,7 +157,12 @@ class DepositIntegration:
             # and don't implement KYC by default
             return
 
-        return {"form": (TransactionForm, {})}
+        if post_data:
+            form = TransactionForm(transaction.asset, post_data)
+        else:
+            form = TransactionForm(transaction.asset, initial=prefill_data)
+
+        return {"form": form}
 
     @classmethod
     def after_form_validation(cls, form: forms.Form, transaction: Transaction):
@@ -243,7 +254,12 @@ class WithdrawalIntegration:
         )
 
     @classmethod
-    def content_for_transaction(cls, transaction: Transaction) -> Optional[Dict]:
+    def content_for_transaction(
+        cls,
+        transaction: Transaction,
+        post_data: Optional[QueryDict] = None,
+        prefill_data: Optional[Dict] = None,
+    ) -> Optional[Dict]:
         """
         Same as :func:`DepositIntegration.content_for_transaction`
 
@@ -256,7 +272,12 @@ class WithdrawalIntegration:
             # and don't implement KYC by default
             return
 
-        return {"form": (TransactionForm, {})}
+        if post_data:
+            form = TransactionForm(transaction.asset, post_data)
+        else:
+            form = TransactionForm(transaction.asset, initial=prefill_data)
+
+        return {"form": form}
 
     @classmethod
     def after_form_validation(cls, form: TransactionForm, transaction: Transaction):

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -74,7 +74,7 @@ class DepositIntegration:
         cls,
         transaction: Transaction,
         post_data: Optional[QueryDict] = None,
-        prefill_data: Optional[Dict] = None,
+        amount: Optional[Decimal] = None,
     ) -> Optional[Dict]:
         """
         This function should return a dictionary containing the next form class
@@ -160,7 +160,7 @@ class DepositIntegration:
         if post_data:
             form = TransactionForm(transaction.asset, post_data)
         else:
-            form = TransactionForm(transaction.asset, initial=prefill_data)
+            form = TransactionForm(transaction.asset, initial={"amount": amount})
 
         return {"form": form}
 
@@ -258,7 +258,7 @@ class WithdrawalIntegration:
         cls,
         transaction: Transaction,
         post_data: Optional[QueryDict] = None,
-        prefill_data: Optional[Dict] = None,
+        amount: Optional[Decimal] = None,
     ) -> Optional[Dict]:
         """
         Same as :func:`DepositIntegration.content_for_transaction`
@@ -275,7 +275,7 @@ class WithdrawalIntegration:
         if post_data:
             form = TransactionForm(transaction.asset, post_data)
         else:
-            form = TransactionForm(transaction.asset, initial=prefill_data)
+            form = TransactionForm(transaction.asset, initial={"amount": amount})
 
         return {"form": form}
 

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -28,7 +28,7 @@ class DepositIntegration:
 
         For every transaction that is returned, Polaris will submit it to the
         Stellar network. If a transaction was completed on the network, the
-        overridable :meth:`after_deposit` function will be called, however
+        overridable ``after_deposit`` function will be called, however
         implementing this function is optional.
 
         If the Stellar network is unable to execute a transaction returned
@@ -64,7 +64,7 @@ class DepositIntegration:
         users about completed deposits. Overriding this function is not
         required.
 
-        :param transaction: a :class:`Transaction` that was executed on the
+        :param transaction: a ``Transaction`` that was executed on the
             Stellar network
         """
         pass
@@ -162,10 +162,10 @@ class DepositIntegration:
         """
         Use this function to process the data collected with `form` and to update
         the state of the interactive flow so that the next call to
-        :func:`DepositIntegration.content_for_transaction` returns a dictionary
+        ``DepositIntegration.content_for_transaction`` returns a dictionary
         containing the next form to render to the user, or returns None.
 
-        Keep in mind that if a :class:`TransactionForm` is submitted, Polaris will
+        Keep in mind that if a ``TransactionForm`` is submitted, Polaris will
         update the `amount_in` and `amount_fee` with the information collected.
         There is no need to implement that yourself.
 
@@ -174,11 +174,11 @@ class DepositIntegration:
         particular values at different points in the flow.
 
         If you need to store some data to determine which form to return next when
-        :func:`DepositIntegration.content_for_transaction` is called, store this
+        ``DepositIntegration.content_for_transaction`` is called, store this
         data in a model not used by Polaris.
 
-        :param form: the completed :class:`forms.Form` submitted by the user
-        :param transaction: the :class:`Transaction` database object
+        :param form: the completed ``forms.Form`` submitted by the user
+        :param transaction: the ``Transaction`` database object
         """
         pass
 
@@ -220,7 +220,7 @@ class WithdrawalIntegration:
     The container class for withdrawal integration functions
 
     Subclasses must be registered with Polaris by passing it to
-    :func:`polaris.integrations.register_integrations`.
+    ``polaris.integrations.register_integrations``.
     """
 
     @classmethod
@@ -240,7 +240,7 @@ class WithdrawalIntegration:
 
         :param response: a response body returned from Horizon for the transactions
             for account endpoint_
-        :param transaction: a :class:`Transaction` instance to process
+        :param transaction: a ``Transaction`` instance to process
         """
         raise NotImplementedError(
             "`process_withdrawal` must be implemented to process withdrawals"
@@ -257,7 +257,7 @@ class WithdrawalIntegration:
         .. _django request.POST: https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.HttpRequest.POST
         .. _SEP-9: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md
 
-        Same as :func:`DepositIntegration.content_for_transaction`
+        Same as ``DepositIntegration.content_for_transaction``
 
         :param transaction: the ``Transaction`` database object
         :param post_data: A `django request.POST`_ object
@@ -282,11 +282,11 @@ class WithdrawalIntegration:
     @classmethod
     def after_form_validation(cls, form: TransactionForm, transaction: Transaction):
         """
-        Same as :func:`DepositIntegration.after_form_validation`, except
+        Same as ``DepositIntegration.after_form_validation``, except
         `transaction.to_address` should be saved here when present in `form`.
 
-        :param form: the completed :class:`forms.Form` submitted by the user
-        :param transaction: the :class:`Transaction` database object
+        :param form: the completed ``forms.Form`` submitted by the user
+        :param transaction: the ``Transaction`` database object
         """
         pass
 

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -187,9 +187,7 @@ def get_interactive_withdraw(request: Request) -> Response:
            cookie should still be included in the response so future calls to
            GET /transactions/withdraw/interactive/complete are authenticated.
         3. content_for_transaction() is called to retrieve the next form to
-           render to the user. `amount` is prepopulated in the form if it was
-           passed as a parameter to this endpoint and the form is a subclass
-           of TransactionForm.
+           render to the user.
         4. get and post URLs are constructed with the appropriate arguments
            and passed to the response to be rendered to the user.
     """

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -5,7 +5,6 @@ non-Stellar-based account.
 """
 from urllib.parse import urlencode
 
-from django.forms import Form
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.shortcuts import redirect

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -206,7 +206,7 @@ def get_interactive_withdraw(request: Request) -> Response:
     if url:  # The anchor uses a standalone interactive flow
         return redirect(url)
 
-    content = rwi.content_for_transaction(transaction, prefill_data={"amount": amount})
+    content = rwi.content_for_transaction(transaction, amount=amount)
     if not content:
         logger.error("The anchor did not provide content, unable to serve page.")
         if transaction.status != transaction.STATUS.incomplete:

--- a/polaris/polaris/withdraw/views.py
+++ b/polaris/polaris/withdraw/views.py
@@ -73,7 +73,7 @@ def post_interactive_withdraw(request: Request) -> Response:
     callback = args_or_error["callback"]
     amount = args_or_error["amount"]
 
-    content = rwi.content_for_transaction(transaction)
+    content = rwi.content_for_transaction(transaction, post_data=request.POST)
     if not (content and content.get("form")):
         logger.error(
             "Initial content_for_transaction() call returned None "
@@ -94,7 +94,7 @@ def post_interactive_withdraw(request: Request) -> Response:
         )
 
     try:
-        form_class, form_args = content.get("form")
+        form = content.get("form")
     except TypeError:
         logger.exception("content_for_transaction(): 'form' key value must be a tuple")
         return render_error_response(
@@ -103,14 +103,8 @@ def post_interactive_withdraw(request: Request) -> Response:
             content_type="text/html",
         )
 
-    is_transaction_form = issubclass(form_class, TransactionForm)
-    if is_transaction_form:
-        form = form_class(asset, request.POST, **form_args)
-    else:
-        form = form_class(request.POST, **form_args)
-
     if form.is_valid():
-        if is_transaction_form:
+        if issubclass(form.__class__, TransactionForm):
             fee_params = {
                 "operation": settings.OPERATION_WITHDRAWAL,
                 "asset_code": asset.code,
@@ -121,8 +115,8 @@ def post_interactive_withdraw(request: Request) -> Response:
             transaction.save()
 
         rwi.after_form_validation(form, transaction)
-        content = rwi.content_for_transaction(transaction)
-        if content:
+
+        if rwi.content_for_transaction(transaction):
             args = {"transaction_id": transaction.id, "asset_code": asset.code}
             if amount:
                 args["amount"] = amount
@@ -130,6 +124,7 @@ def post_interactive_withdraw(request: Request) -> Response:
                 args["callback"] = callback
             url = reverse("get_interactive_withdraw")
             return redirect(f"{url}?{urlencode(args)}")
+
         else:  # Last form has been submitted
             logger.info(
                 f"Finished data collection and processing for transaction {transaction.id}"
@@ -211,7 +206,7 @@ def get_interactive_withdraw(request: Request) -> Response:
     if url:  # The anchor uses a standalone interactive flow
         return redirect(url)
 
-    content = rwi.content_for_transaction(transaction)
+    content = rwi.content_for_transaction(transaction, prefill_data={"amount": amount})
     if not content:
         logger.error("The anchor did not provide content, unable to serve page.")
         if transaction.status != transaction.STATUS.incomplete:
@@ -229,26 +224,6 @@ def get_interactive_withdraw(request: Request) -> Response:
         )
 
     scripts = registered_scripts_func(content)
-
-    if content.get("form"):
-        try:
-            form_class, form_args = content.get("form")
-        except TypeError:
-            logger.exception(
-                "content_for_transaction(): 'form' key value must be a tuple"
-            )
-            return render_error_response(
-                _("The anchor did not provide content, unable to serve page."),
-                status_code=500,
-                content_type="text/html",
-            )
-        is_transaction_form = issubclass(form_class, TransactionForm)
-        if is_transaction_form:
-            content["form"] = form_class(
-                asset, initial={"amount": amount}, test_value="100", **form_args
-            )
-        else:
-            content["form"] = form_class(**form_args)
 
     url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
     if callback:


### PR DESCRIPTION
This change is in preparation for #179 , which will allow anchors to prefill their forms with parameters from SEP-9. The intention is to simply the flow for prefilling a form's fields.

**Problem Statement**
Without this change, (as #179 is implemented now), anchors must return a dictionary of initialization arguments from `content_for_transaction()` that will then be passed to the form's constructor by Polaris.

This is not a clean design because this dictionary would now contain two types of data: data that is specific to the anchor's logic (the original purpose of the design), and SEP-9 parameters for pre-filling the form. Anchors would need to separate the two types of data from the original dictionary and call `super().__init__(initial=prefill_data)` in the form's `__init__()` function.

**Solution**
Instead, we can give the anchor more control by allowing them to initialize their own forms, removing the need for them to return initialization arguments from `content_for_transaction()` and define an `__init__()` to call `super().__init__(initial=)`.

**Drawbacks**
The downside of this change is its a breaking change, specifically for `content_for_transaction()`
1. Changing the returned dict's "form" key from a tuple to an initialized form object
2. Adding two keyword arguments to `content_for_transaction()`
    - `post_data`: the data POSTed by the wallet that the anchor will now need to pass to the form's constructor when non-`None`
    - `amount`: the amount the wallet sent in the GET request for the form. The anchor should use it to prefill its `TransactionForm` if non-`None`

The second drawback adds complexity to the anchor's `content_for_transaction()` implementation, but overall I think this simplifies the API and the data flow.