### PR TITLE
Allow differing amounts in watch_transactions

### DIFF
--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -317,9 +317,25 @@ class WithdrawalIntegration:
         """
         .. _endpoint: https://www.stellar.org/developers/horizon/reference/resources/transaction.html
 
-        This method should implement the transfer of the amount of the
-        anchored asset specified by `transaction` to the user who requested
-        the withdrawal.
+        This method is called when the transacted asset's distribution account receives
+        a payment from a transaction with a memo matching `transaction.memo`.
+
+        If `transaction` was created via SEP-24, it is very important to confirm
+        the amount sent in on the network matches the amount specified by
+        `transaction.amount_in`. This does not apply to SEP-6 transactions since
+        withdrawal amounts are not specified in the initial request.
+
+        If the amounts match, or in the SEP-6 case, the amount sent is within the
+        asset's minimum and maximum limits, make the corresponding deposit to the
+        user's non-stellar account.
+
+        If the amount doesn't match, you must decide whether or not to complete the
+        withdraw or refund the sender. If the amount sent was greater than originally
+        expected, you could also deposit the amount specified by `amount_in` and
+        refund the remaining amount back to the sender.
+
+        If you chose to refund the payment in its entirety, raise an exception with
+        an appropriate message and update `transaction.refunded` to ``True``.
 
         If an error is raised from this function, the transaction's status
         will be changed to ``error`` and its ``status_message`` will be

--- a/polaris/polaris/management/commands/watch_transactions.py
+++ b/polaris/polaris/management/commands/watch_transactions.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
     Streams transactions from stellar accounts provided in the configuration file
 
     For every response from the server, attempts to find a matching transaction in
-    the database with `match_transactions`, and processes the transactions
+    the database with `find_matching_payment_op`, and processes the transactions
     using `process_withdrawal`. Finally, the transaction is updated depending on
     the successful processing of the transaction with `update_transaction`.
 
@@ -208,7 +208,6 @@ class Command(BaseCommand):
     def _check_payment_op(
         operation: Operation, want_asset: Asset, want_amount: Optional[Decimal]
     ) -> bool:
-        # TODO: Add test cases!
         return (
             operation.type_code() == Xdr.const.PAYMENT
             and str(operation.destination.account_id) == want_asset.distribution_account

--- a/polaris/polaris/sep24/deposit.py
+++ b/polaris/polaris/sep24/deposit.py
@@ -265,6 +265,11 @@ def deposit(account: str, request: Request) -> Response:
         return render_error_response(
             _("`asset_code` and `account` are required parameters")
         )
+    elif request.POST.get("memo"):
+        # Polaris SEP-24 doesn't support custodial wallets that depend on memos
+        # to disambiguate users using the same stellar account. Support would
+        # require new or adjusted integration points.
+        return render_error_response(_("`memo` parameter is not supported"))
 
     # Verify that the asset code exists in our database, with deposit enabled.
     asset = Asset.objects.filter(code=asset_code).first()

--- a/polaris/polaris/sep24/withdraw.py
+++ b/polaris/polaris/sep24/withdraw.py
@@ -259,6 +259,11 @@ def withdraw(account: str, request: Request) -> Response:
         activate_lang_for_request(lang)
     if not asset_code:
         return render_error_response(_("'asset_code' is required"))
+    elif request.POST.get("memo"):
+        # Polaris SEP-24 doesn't support custodial wallets that depend on memos
+        # to disambiguate users using the same stellar account. Support would
+        # require new or adjusted integration points.
+        return render_error_response(_("`memo` parameter is not supported"))
 
     # Verify that the asset code exists in our database, with withdraw enabled.
     asset = Asset.objects.filter(code=asset_code).first()

--- a/polaris/polaris/sep6/deposit.py
+++ b/polaris/polaris/sep6/deposit.py
@@ -7,7 +7,6 @@ from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
 from stellar_sdk.exceptions import MemoInvalidException
 
-from polaris import settings
 from polaris.models import Asset, Transaction
 from polaris.locale.utils import validate_language, activate_lang_for_request
 from polaris.utils import (

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -22,7 +22,7 @@ WEBAPP_PATH = "/sep24/transactions/deposit/webapp"
 DEPOSIT_PATH = "/sep24/transactions/deposit/interactive"
 HORIZON_SUCCESS_RESPONSE = {
     "result_xdr": SUCCESS_XDR,
-    "hash": "test_stellar_id",
+    "id": "test_stellar_id",
     "paging_token": "123456789",
 }
 # Test client account and seed

--- a/polaris/polaris/utils.py
+++ b/polaris/polaris/utils.py
@@ -275,7 +275,7 @@ def create_stellar_deposit(transaction_id: str) -> bool:
         return False
 
     transaction.paging_token = response["paging_token"]
-    transaction.stellar_transaction_id = response["hash"]
+    transaction.stellar_transaction_id = response["id"]
     transaction.status = Transaction.STATUS.completed
     transaction.completed_at = datetime.datetime.now(datetime.timezone.utc)
     transaction.status_eta = 0  # No more status change.


### PR DESCRIPTION
resolves stellar/django-polaris#196

Before this change, funds sent to an anchor's distribution account had to exactly match the amount specified by the user during the interactive flow. This change removes that requirement and now allows the anchor to decide how to handle differing amounts.

Since transactions submitted to Horizon and `Transaction` DB objects in Polaris can no longer be matched using the amount, `memo` is now the only deterministic way to find a match. 

On both SEP 6 and 24, the `memo` request parameter for `/withdraw` and the `memo` attribute returned by the `/transaction` endpoint have different uses. `memo` sent in the request should be used by the anchor to disambiguate users who use the same stellar account, whereas `memo` returned in the `/transaction` endpoint response should be used by the wallet when submitting the transaction.

So, this PR also ensures that both SEP 6 and SEP24 withdrawal transactions have memo's created by the anchor in order to later match them with transactions sent over the network by the wallet. Previously, SEP-6 would use the `memo` sent in the `/withdraw` request and leave it `null` if one was not sent.

This PR also currently returns 400 for memo's sent by clients to SEP-24 `/deposit` and `/withdraw` endpoints, since we do not want to give clients the impression that Polaris SEP-24 supports custodial wallet withdraws. This policy may change.