### PR TITLE
Disable secure session cookie when in local mode

### DIFF
--- a/polaris/polaris/middleware.py
+++ b/polaris/polaris/middleware.py
@@ -40,8 +40,12 @@ class PolarisSameSiteMiddleware:
         # Code to be executed for each request/response after
         # the view is called.
         from django.conf import settings
+        from polaris import settings as polaris_settings
 
-        if settings.SESSION_COOKIE_NAME in response.cookies:
+        if (
+            settings.SESSION_COOKIE_NAME in response.cookies
+            and not polaris_settings.LOCAL_MODE
+        ):
             response.cookies[settings.SESSION_COOKIE_NAME]["samesite"] = "None"
             response.cookies[settings.SESSION_COOKIE_NAME]["secure"] = True
 


### PR DESCRIPTION
Our custom middleware was adding the `Secure` flag to session cookie thats created when you login to the admin panel. This PR disables use of that flag when in local mode.

Side note: Do we want to continue using PolarisSameSiteMiddleware? This was a fix for iframes, which we no longer recommend in the SEP.