### PR TITLE
Allow 'id' to be returned from GET /customer

### DIFF
--- a/example/server/integrations.py
+++ b/example/server/integrations.py
@@ -476,12 +476,15 @@ class MyCustomerIntegration(CustomerIntegration):
                 )
         else:
             user = account.user
+            response_data = {"id": user.id}
             if (user.bank_number and user.bank_account_number) or (
                 params.get("type") in ["sep6-deposit", "sep31-sender", "sep31-receiver"]
             ):
-                return self.accepted
+                response_data.update(self.accepted)
+                return response_data
             elif params.get("type") in [None, "sep6-withdraw"]:
-                return self.needs_bank_info
+                response_data.update(self.needs_bank_info)
+                return response_data
             else:
                 raise ValueError(
                     _("invalid 'type'. see /info response for valid values.")

--- a/polaris/polaris/sep12/customer.py
+++ b/polaris/polaris/sep12/customer.py
@@ -118,8 +118,14 @@ def delete(account_from_auth: str, request: Request, account: str) -> Response:
 
 
 def validate_response_data(data: Dict):
+    attrs = ["fields", "id", "message", "status"]
     if not data:
         raise ValueError("empty response from SEP-12 get() integration")
+    elif any(f not in attrs for f in data):
+        raise ValueError(
+            f"unexpected attribute included in GET /customer response. "
+            f"Accepted attributes: {attrs}"
+        )
     accepted_statuses = ["ACCEPTED", "PROCESSING", "NEEDS_INFO", "REJECTED"]
     if not data.get("status") or data.get("status") not in accepted_statuses:
         raise ValueError("invalid status in SEP-12 GET /customer response")

--- a/polaris/polaris/tests/sep12/test_customer.py
+++ b/polaris/polaris/tests/sep12/test_customer.py
@@ -170,7 +170,7 @@ def test_sep9_params(client):
     assert response.json() == {"id": "123"}
 
 
-mock_get_accepted = Mock(return_value={"status": "ACCEPTED"})
+mock_get_accepted = Mock(return_value={"status": "ACCEPTED", "id": "123"})
 
 
 @patch("polaris.sep12.customer.rci.get", mock_get_accepted)
@@ -180,6 +180,7 @@ def test_get_accepted(client):
         endpoint + "?" + urlencode({"account": "test source address"})
     )
     assert response.status_code == 200
+    assert response.json() == {"status": "ACCEPTED", "id": "123"}
 
 
 @patch("polaris.sep12.customer.rci.get", Mock())
@@ -263,6 +264,7 @@ def test_get_missing_memo_type(client):
     "polaris.sep12.customer.rci.get",
     Mock(
         return_value={
+            "id": "123",
             "status": "NEEDS_INFO",
             "fields": {
                 "email_address": {
@@ -279,6 +281,16 @@ def test_valid_needs_info_response(client):
         endpoint + "?" + urlencode({"account": "test source address"})
     )
     assert response.status_code == 200
+    assert response.json() == {
+        "id": "123",
+        "status": "NEEDS_INFO",
+        "fields": {
+            "email_address": {
+                "description": "Email address of the user",
+                "type": "string",
+            }
+        },
+    }
 
 
 @patch(


### PR DESCRIPTION
Polaris update for adding the `id` attribute to the GET /customer response.