### PR TITLE
Breaking changes: Rails Integrations

### DIFF
--- a/docs/sep31/index.rst
+++ b/docs/sep31/index.rst
@@ -93,13 +93,13 @@ Poll Outgoing Transactions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 And finally, once a payment to the user has been initiated by the anchor, this CLI tool
-periodically calls ``RailsIntegration.poll_outgoing_transactions`` so the anchor can
+periodically calls ``RailsIntegration.poll_outgoing_transactions()`` so the anchor can
 return the transactions that have have completed, meaning the user has received the funds.
 
 If your banking or payment rails do not provide the necessary information to check if the
 user has received funds, do not run this process and simply mark each transaction
 as ``Transaction.STATUS.completed`` after initiating the payment in
-``RailsIntegration.execute_outgoing_transaction``.
+``RailsIntegration.execute_outgoing_transaction()``.
 
 Run the process like so:
 ::

--- a/docs/sep6_and_sep24/index.rst
+++ b/docs/sep6_and_sep24/index.rst
@@ -126,27 +126,24 @@ share many of the same integrations. We'll go over these integrations first, the
 the integrations specific to each SEP.
 
 Polaris provides a set of base classes that should be subclassed for processing
-transactions, ``DepositIntegration`` and ``WithdrawalIntegration``. These subclasses,
-along with several other integration functions, should be registered with Polaris once
-implemented. See the :doc:`Registering Integrations</register_integrations/index>`
-section for more information.
+transactions, ``DepositIntegration``, ``WithdrawalIntegration``, and
+``RailsIntegration``.
+
+These subclasses, along with several other integration functions, should be
+registered with Polaris once implemented. See the
+:doc:`Registering Integrations</register_integrations/index>` section for more
+information.
 
 Banking Rails
 ^^^^^^^^^^^^^
 
-Polaris doesn't have the information it needs to interface with an
-anchor's partner financial entities. That is why Polaris provides a set of
-integration functions for anchors to implement.
+One of the pieces of SEP-6 and SEP-24 Polaris cannot implement itself is the API
+connection to an anchor's partner financial entity. That is why Polaris provides a
+set of integration functions for anchors to implement themselves.
 
-Note that in future releases, some of these functions related to payment rails
-may be moved from ``DepositIntegration`` or ``WithdrawalIntegration`` to
-``RailsIntegration``.
+.. autofunction:: polaris.integrations.RailsIntegration.poll_pending_deposits
 
-.. autofunction:: polaris.integrations.DepositIntegration.poll_pending_deposits
-
-.. autofunction:: polaris.integrations.DepositIntegration.after_deposit
-
-.. autofunction:: polaris.integrations.WithdrawalIntegration.process_withdrawal
+.. autofunction:: polaris.integrations.RailsIntegration.execute_outgoing_transaction
 
 Fee Integration
 ^^^^^^^^^^^^^^^
@@ -158,8 +155,16 @@ Deposit Instructions
 
 .. autofunction:: polaris.integrations.DepositIntegration.instructions_for_pending_deposit
 
+Deposit Post-Processing
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: polaris.integrations.DepositIntegration.after_deposit
+
 SEP-6 Integrations
 ------------------
+
+The previous integrations are available for both SEP-6 and SEP-24 transactions, but
+the functions described below are only for SEP-6.
 
 .. autofunction:: polaris.integrations.DepositIntegration.process_sep6_request
 
@@ -222,6 +227,7 @@ parameter can also be included in the URL.
 .. autofunction:: polaris.integrations.DepositIntegration.interactive_url
 
 .. autofunction:: polaris.integrations.WithdrawalIntegration.interactive_url
+
 
 Javascript Integration
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/example/server/integrations.py
+++ b/example/server/integrations.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import json
 from smtplib import SMTPException
 from decimal import Decimal
@@ -101,7 +99,7 @@ class SEP24KYC:
                 )
 
         PolarisUserTransaction.objects.get_or_create(
-            account=account, transaction_id=transaction.id
+            user=account.user, account=account, transaction_id=transaction.id
         )
 
     @staticmethod
@@ -148,35 +146,6 @@ class SEP24KYC:
 
 
 class MyDepositIntegration(DepositIntegration):
-    def poll_pending_deposits(self, pending_deposits: QuerySet) -> List[Transaction]:
-        """
-        Anchors should implement their banking rails here, as described
-        in the :class:`.DepositIntegration` docstrings.
-
-        This implementation interfaces with a fake banking rails client
-        for demonstration purposes.
-        """
-        # interface with mock banking rails
-        ready_deposits = []
-        mock_bank_account_id = "XXXXXXXXXXXXX"
-        client = rails.BankAPIClient(mock_bank_account_id)
-        for deposit in pending_deposits:
-            bank_deposit = client.get_deposit(deposit=deposit)
-            if bank_deposit and bank_deposit.status == "complete":
-                if not deposit.amount_in:
-                    deposit.amount_in = Decimal(103)
-                    deposit.amount_fee = calculate_fee(
-                        {
-                            "amount": 103,
-                            "operation": settings.OPERATION_DEPOSIT,
-                            "asset_code": deposit.asset.code,
-                        }
-                    )
-                    deposit.save()
-                ready_deposits.append(deposit)
-
-        return ready_deposits
-
     def instructions_for_pending_deposit(self, transaction: Transaction):
         """
         This function provides a message to the user containing instructions for
@@ -279,16 +248,6 @@ class MyDepositIntegration(DepositIntegration):
 
 
 class MyWithdrawalIntegration(WithdrawalIntegration):
-    def process_withdrawal(self, response: Dict, transaction: Transaction):
-        logger.info(f"Processing transaction {transaction.id}")
-
-        mock_bank_account_id = "XXXXXXXXXXXXX"
-        client = rails.BankAPIClient(mock_bank_account_id)
-        client.send_funds(
-            to_account=transaction.to_address,
-            amount=transaction.amount_in - transaction.amount_fee,
-        )
-
     def content_for_transaction(
         self, transaction: Transaction, post_data=None, amount=None
     ) -> Optional[Dict]:
@@ -586,7 +545,7 @@ class MySendIntegration(SendIntegration):
         }
 
     def process_send_request(self, params: Dict, transaction_id: str) -> Optional[Dict]:
-        sender_id = params.get("sender_id")  # not actually used
+        _ = params.get("sender_id")  # not actually used
         receiver_id = params.get("receiver_id")
         transaction_fields = params.get("fields", {}).get("transaction")
         for field, val in transaction_fields.items():
@@ -638,6 +597,35 @@ class MySendIntegration(SendIntegration):
 
 
 class MyRailsIntegration(RailsIntegration):
+    def poll_pending_deposits(self, pending_deposits: QuerySet) -> List[Transaction]:
+        """
+        Anchors should implement their banking rails here, as described
+        in the :class:`.RailsIntegration` docstrings.
+
+        This implementation interfaces with a fake banking rails client
+        for demonstration purposes.
+        """
+        # interface with mock banking rails
+        ready_deposits = []
+        mock_bank_account_id = "XXXXXXXXXXXXX"
+        client = rails.BankAPIClient(mock_bank_account_id)
+        for deposit in pending_deposits:
+            bank_deposit = client.get_deposit(deposit=deposit)
+            if bank_deposit and bank_deposit.status == "complete":
+                if not deposit.amount_in:
+                    deposit.amount_in = Decimal(103)
+                    deposit.amount_fee = calculate_fee(
+                        {
+                            "amount": 103,
+                            "operation": settings.OPERATION_DEPOSIT,
+                            "asset_code": deposit.asset.code,
+                        }
+                    )
+                    deposit.save()
+                ready_deposits.append(deposit)
+
+        return ready_deposits
+
     def poll_outgoing_transactions(self, transactions: QuerySet) -> List[Transaction]:
         """
         Auto-complete pending_external transactions
@@ -648,11 +636,30 @@ class MyRailsIntegration(RailsIntegration):
         return list(transactions)
 
     def execute_outgoing_transaction(self, transaction: Transaction):
-        user = (
-            PolarisUserTransaction.objects.filter(transaction_id=transaction.id)
-            .first()
-            .user
-        )
+        def error():
+            transaction.status = Transaction.STATUS.error
+            transaction.status_message = (
+                f"Unable to find user info for transaction {transaction.id}"
+            )
+            transaction.save()
+
+        user_transaction = PolarisUserTransaction.objects.filter(
+            transaction_id=transaction.id
+        ).first()
+        if not user_transaction:  # something is wrong with our user tracking code
+            error()
+            return
+
+        # SEP31 users don't have stellar accounts, so check the user column on the transaction.
+        # Since that is a new column, it may be None. If so, use the account's user column
+        if user_transaction.user:
+            user = user_transaction.user
+        else:
+            user = getattr(user_transaction.account, "user", None)
+
+        if not user:  # something is wrong with our user tracking code
+            error()
+            return
 
         client = rails.BankAPIClient("fake anchor bank account number")
         transaction.amount_fee = 0  # Or calculate your fee

--- a/polaris/polaris/integrations/rails.py
+++ b/polaris/polaris/integrations/rails.py
@@ -28,68 +28,98 @@ class RailsIntegration:
     def execute_outgoing_transaction(self, transaction: Transaction):
         """
         Send the amount of the off-chain asset specified by `transaction` minus fees
-        to the user associated with `transaction`. Don't forget to populate the
-        ``Transaction.amount_fee`` attribute if non-zero.
+        to the user associated with `transaction`. This function is used for SEP-6 &
+        SEP-24 withdraws as well as SEP-31 payments.
+
+        At the time of calling this function, ``transaction.amount_in`` has been
+        assigned the value of the amount sent in the Stellar transaction, and `this
+        amount may differ from the value specified in the original request for the
+        transaction`. Validate the amount and recalculate ``transaction.amount_fee``
+        if its valid.
+
+        If the amount is invalid in some way, the anchor must choose how to handle it.
+        If you choose to refund the payment in its entirety, change ``transaction.status``
+        to `"error"`, assign an appropriate message to ``transaction.status_message``,
+        and update `transaction.refunded` to ``True``.
+
+        You could also refund a portion of the amount and continue processing the
+        remaining amount. In this case, the ``transaction.status`` column should be
+        assigned one of the expected statuses for this function, mentioned below, and
+        the ``amount_in`` field should be reassigned the value the anchor is accepted.
 
         If the user receives the funds before returning from this function,
         update ``Transaction.status`` to ``Transaction.STATUS.completed``.
         If the transfer was simply initiated and is pending external systems,
         update the status to ``Transaction.STATUS.pending_external``.
 
-        If more information is required from the sending anchor or user to complete
-        the transaction, update the status to ``Transaction.STATUS.pending_info_update``
-        and save necessary fields to the ``Transaction.required_info_update`` field
-        in the same format returned from ``SendIntegration.info()``. You can also
-        optionally save a human readable message to ``Transaction.required_info_message``.
-        Both fields will included in the `/transaction` response requested by the
-        sending anchor.
-
-        If the transaction is waiting for an update, the sending anchor will eventually
-        make a request to the `/update` endpoint with the information specified in
-        ``Transaction.required_info_update``. Once updated, this function will be
-        called again with the updated transaction.
-
         If an exception is raised, the transaction will be left in
         its current status and may be used again as a parameter to this function.
         To ensure the exception isn't repeatedly re-raised, change the problematic
         transaction's status to ``Transaction.STATUS.error``.
 
-        Currently, only SEP31 payment transactions are passed to this function,
-        but SEP24 and SEP6 withdrawal transactions will be passed in future
-        releases instead of using ``WithdrawalIntegration.process_withdrawal()``.
+        If ``transaction.protocol == Transaction.PROTOCOL.sep31`` and more information
+        is required from the sending anchor or user to complete the transaction, update
+        the status to ``Transaction.STATUS.pending_info_update`` and save a JSON-serialized
+        string of the missing fields to the ``Transaction.required_info_update`` column.
+        The JSON string should be in the format returned from ``SendIntegration.info()``.
+        You can also optionally save a human-readable message to
+        ``Transaction.required_info_message``. Both fields will included in the
+        `/transaction` response requested by the sending anchor.
+
+        If the SEP-31 transaction is waiting for an update, the sending anchor will
+        eventually make a request to the `/update` endpoint with the information
+        specified in ``Transaction.required_info_update``. Once updated, this function
+        will be called again with the updated transaction.
 
         :param transaction: the ``Transaction`` object associated with the payment
             this function should make
         """
         pass
 
-    # TODO: move DepositIntegration.poll_pending_deposits here
-    # DepositIntegration and WithdrawalIntegration should only contain functions
-    # that are needed by unilateral transaction SEPs, such as SEP6 and SEP24.
-    # poll_pending_deposits() is a function that could be used by bilateral
-    # transaction SEPs (like SEP31) that need to watch for incoming deposits
-    # to their accounts.
-    #
-    # Polaris should have designed all rails-related functions to be separate
-    # from the type of transaction being processed, since now it would be a bad
-    # design decision to have SEP31 (bilateral payment) anchors use
-    # DepositIntegration and WithdrawalIntegration.
-    #
-    # For example, both SEP31 and SEP6/24 anchors need to poll their bank/off-chain
-    # transfers (off-chain payments to users after receiving stellar funds).
-    # The difference is that SEP31 anchors are sending funds to a user
-    # who did not deposit funds into the anchor's stellar account, whereas SEP6/24
-    # anchors are. Polaris could've added a poll_pending_transfers function to
-    # both SendIntegration and WithdrawalIntegration, but it is probably better to
-    # allow the anchor to connect to their off-chain rails once for all pending
-    # transfers than twice for payments and withdrawals.
-    #
-    # WithdrawalIntegration.process_withdrawal() may also be moved (and maybe
-    # combined) here in the future, since they are rails-related functions and are
-    # for very similar purposes.
-    #
-    # For now, I want to avoid breaking changes and introduce SEP31 support without
-    # changing the interface for other SEPs.
+    def poll_pending_deposits(self, pending_deposits: QuerySet) -> List[Transaction]:
+        """
+        This function should poll the appropriate financial entity for the
+        state of all `pending_deposits` transactions and return the ones that have
+        externally completed, meaning the off-chain funds are available in the
+        anchor's account.
+
+        Per SEP-24, make sure to save the transaction's ``from_address`` field with
+        the account the funds originated from.
+
+        Also, ensure the amount deposited to the anchor's account matches each
+        transaction's ``amount_in`` field. If ``amount_in`` does not match or is
+        ``None``, which will be the case for SEP-6 and SEP-31 transactions,
+        assign the amount deposited to ``amount_in`` and update ``amount_fee``
+        to appropriately.
+
+        For every transaction that is returned, Polaris will submit it to the
+        Stellar network. If a transaction is completed on the network, the
+        overridable ``after_deposit`` function will be called, however
+        implementing this function is optional.
+
+        If the Stellar network is unable to execute a transaction returned
+        from this function, it's status will be marked as ``error``
+        and its ``status_message`` attribute will be assigned a description of
+        the problem that occurred. If the Stellar network is successful,
+        the transaction will be marked as ``completed``.
+
+        `pending_deposits` is a QuerySet of the form
+        ::
+
+            Transactions.object.filter(
+                kind=Transaction.KIND.deposit,
+                status=Transaction.STATUS.pending_user_transfer_start
+            )
+
+        If you have many pending deposits, you may way want to batch
+        the retrieval of these objects to improve query performance and
+        memory usage.
+
+        :param pending_deposits: a django Queryset for pending Transactions
+        :return: a list of Transaction database objects which correspond to
+            successful user deposits to the anchor's account.
+        """
+        pass
 
 
 registered_rails_integration = RailsIntegration()

--- a/polaris/polaris/integrations/sep31.py
+++ b/polaris/polaris/integrations/sep31.py
@@ -145,7 +145,7 @@ class SendIntegration:
         """
         Return ``True`` if `public_key` is a known anchor's stellar account address,
         and ``False`` otherwise. This function ensures that only registered sending
-        anchors can make `/send` requests.
+        anchors can make requests to protected endpoints.
 
         :param public_key: the public key of the sending anchor's stellar account
         """

--- a/polaris/polaris/management/commands/execute_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/execute_outgoing_transactions.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime, timezone
 
+from django.db.models import Q
 from django.core.management import BaseCommand
 
 from polaris.utils import Logger
@@ -39,13 +40,15 @@ class Command(BaseCommand):
 
     @staticmethod
     def execute_outgoing_transactions():
-        # For the time being this function is only for SEP 31 transactions
-        # Eventually we'll process transfers for SEP 6 and SEP 24 transactions
-        # here as well.
-        transactions = Transaction.objects.filter(
+        sep31_qparams = Q(
             protocol=Transaction.PROTOCOL.sep31,
             status=Transaction.STATUS.pending_receiver,
         )
+        sep6_24_qparams = Q(
+            protocol__in=[Transaction.PROTOCOL.sep24, Transaction.PROTOCOL.sep6],
+            status=Transaction.STATUS.pending_anchor,
+        )
+        transactions = Transaction.objects.filter(sep6_24_qparams | sep31_qparams)
         num_completed = 0
         for transaction in transactions:
             try:

--- a/polaris/polaris/management/commands/execute_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/execute_outgoing_transactions.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
                 "The number of seconds to wait before "
                 "restarting command. Defaults to 30."
             ),
-            default=30,
+            default=10,
         )
 
     def handle(self, *args, **options):

--- a/polaris/polaris/management/commands/poll_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/poll_outgoing_transactions.py
@@ -1,7 +1,6 @@
 import time
 from datetime import datetime, timezone
 
-from django.db.models import Q
 from django.core.management import BaseCommand
 
 from polaris.utils import Logger

--- a/polaris/polaris/management/commands/poll_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/poll_outgoing_transactions.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime, timezone
 
+from django.db.models import Q
 from django.core.management import BaseCommand
 
 from polaris.utils import Logger
@@ -40,7 +41,7 @@ class Command(BaseCommand):
     @staticmethod
     def poll_outgoing_transactions():
         transactions = Transaction.objects.filter(
-            protocol=Transaction.PROTOCOL.sep31,
+            kind__in=[Transaction.KIND.withdrawal, Transaction.KIND.send],
             status=Transaction.STATUS.pending_external,
         )
         try:

--- a/polaris/polaris/management/commands/watch_transactions.py
+++ b/polaris/polaris/management/commands/watch_transactions.py
@@ -2,7 +2,6 @@
 import asyncio
 from typing import Dict, Optional
 from decimal import Decimal
-import datetime
 
 from django.core.management.base import BaseCommand
 from django.db.models import Q
@@ -15,10 +14,6 @@ from stellar_sdk.client.aiohttp_client import AiohttpClient
 
 from polaris import settings
 from polaris.models import Asset, Transaction
-from polaris.integrations import (
-    registered_withdrawal_integration as rwi,
-    registered_fee_func as rfi,
-)
 from polaris.utils import Logger
 
 logger = Logger(__name__)
@@ -26,14 +21,15 @@ logger = Logger(__name__)
 
 class Command(BaseCommand):
     """
-    Streams transactions from stellar accounts provided in the configuration file
+    Streams transactions for the distribution account of each Asset in the DB.
 
     For every response from the server, attempts to find a matching transaction in
-    the database with `find_matching_payment_op`, and processes the transactions
-    using `process_withdrawal`. Finally, the transaction is updated depending on
-    the successful processing of the transaction with `update_transaction`.
+    the database with `find_matching_payment_op` and updates the transaction's
+    status to `pending_anchor` or `pending_receiver` depending on the protocol.
 
-    `process_withdrawal` must be overridden by the developer using Polaris.
+    Then, the ``execute_outgoing_transfer`` process will query for transactions
+    in those statuses and provide the anchor an integration function for executing
+    the payment or withdrawal.
     """
 
     def handle(self, *args, **options):  # pragma: no cover
@@ -126,66 +122,31 @@ class Command(BaseCommand):
             logger.info(f"No match found for stellar transaction {response['id']}")
             return
 
+        # Transaction.amount_in is overwritten with the actual amount sent in the stellar
+        # transaction. This allows anchors to validate the actual amount sent in
+        # execute_outgoing_transactions() and handle invalid amounts appropriately.
+        matching_transaction.amount_in = round(
+            Decimal(payment_op.amount), matching_transaction.asset.significant_decimals,
+        )
+
         # The stellar transaction has been matched with an existing record in the DB.
         # Now the anchor needs to initiate the off-chain transfer of the asset.
         #
-        # For SEP 6 & 24, Polaris expects the anchor to not have any issues when making
-        # this transfer. If there are, Polaris marks the transaction as 'error' which
-        # requires the anchor to manually fix the transaction and retry the transfer.
-        #
-        # SEP 31 transfers could also have issues, such as needing additional updates
-        # to the receiving user's information. However, since the SEP31 Polaris support
-        # hasn't been released yet, Polaris will provide a different interface that provides
-        # anchors the ability to attempt transfers, request updates from the sending anchor,
-        # and retry transfers once updates have been received.
-        #
-        # Polaris' SEP 6 and 24 interface will likely be changed to follow this pattern in
-        # a future non-patch release.
+        # Prior to the 0.12 release, Polaris' SEP-6 and 24 integrations didn't not
+        # provide an interface that allowed anchors to check on the state of
+        # transactions on an external network. Now, ``poll_outgoing_transactions()``
+        # allows anchors to check on transactions that have been submitted to a
+        # non-stellar payment network but have not completed, and expects anchors to
+        # update them when they have.
         if matching_transaction.protocol == Transaction.PROTOCOL.sep31:
-            matching_transaction.amount_in = round(
-                Decimal(payment_op.amount),
-                matching_transaction.asset.significant_decimals,
-            )
+            # SEP-31 uses 'pending_receiver' status
             matching_transaction.status = Transaction.STATUS.pending_receiver
             matching_transaction.save()
-            return
-        elif matching_transaction.protocol == Transaction.PROTOCOL.sep6:
-            # Transaction amount is not specified in SEP6 until the actual withdrawal
-            # has been made.
-            matching_transaction.amount_in = round(
-                Decimal(payment_op.amount),
-                matching_transaction.asset.significant_decimals,
-            )
-            # In the future rfi (fee integration) will only be called when a request to
-            # /fee is made. Fee calculations for a specific transaction will be done by
-            # the anchor in process_payment(), process_withdrawal(), or
-            # poll_pending_deposits().
-            #
-            # This makes sense because amount's sent (and indirectly, fee's calculated)
-            # may differ from the amount specified in a SEP 24 or 31 initial
-            # deposit/withdraw/send request. This will also allow us to simply the
-            # fee integration parameters (without changing the function signature).
-            matching_transaction.amount_fee = rfi(
-                {
-                    "amount": matching_transaction.amount_in,
-                    "asset_code": matching_transaction.asset.code,
-                    "operation": settings.OPERATION_WITHDRAWAL,
-                }
-            )
-
-        matching_transaction.status = Transaction.STATUS.pending_anchor
-        matching_transaction.save()
-        try:
-            rwi.process_withdrawal(response, matching_transaction)
-        except Exception as e:
-            cls.update_transaction(response, matching_transaction, error_msg=str(e))
-            logger.exception("process_withdrawal() integration raised an exception")
         else:
-            cls.update_transaction(response, matching_transaction)
-            logger.info(
-                f"successfully processed withdrawal for response with "
-                f"xdr {response['envelope_xdr']}"
-            )
+            # SEP-6 and 24 uses 'pending_anchor' status
+            matching_transaction.status = Transaction.STATUS.pending_anchor
+            matching_transaction.save()
+        return
 
     @classmethod
     def find_matching_payment_op(
@@ -229,42 +190,13 @@ class Command(BaseCommand):
             if cls._check_payment_op(operation, transaction.asset):
                 transaction.stellar_transaction_id = stellar_transaction_id
                 transaction.from_address = horizon_tx.source.public_key
+                transaction.paging_token = response["paging_token"]
+                transaction.status_eta = 0
                 transaction.save()
                 matching_payment_op = operation
                 break
 
         return matching_payment_op
-
-    @staticmethod
-    def update_transaction(
-        response: Dict, transaction: Transaction, error_msg: str = None
-    ):
-        """
-        Updates the transaction depending on whether or not the transaction was
-        successfully executed on the Stellar network and `process_withdrawal` or
-        `process_payment` completed without raising an exception.
-
-        If the Horizon response indicates the response was not successful or an
-        exception was raised while processing the withdrawal, we mark the status
-        as `error`. If the transfer succeeded, we mark the transaction as
-        `completed` unless the anchor updated it to `pending_external`.
-
-        :param error_msg: a description of the error that has occurred.
-        :param response: a response body returned from Horizon for the transaction
-        :param transaction: a database model object representing the transaction
-        """
-        if error_msg or not response["successful"]:
-            transaction.status = Transaction.STATUS.error
-            transaction.status_message = error_msg
-        else:
-            transaction.status = Transaction.STATUS.completed
-            transaction.completed_at = datetime.datetime.now(datetime.timezone.utc)
-            transaction.amount_out = transaction.amount_in - transaction.amount_fee
-            transaction.paging_token = response["paging_token"]
-
-        transaction.status_eta = 0
-        transaction.stellar_transaction_id = response["id"]
-        transaction.save()
 
     @staticmethod
     def _check_payment_op(operation: Operation, want_asset: Asset) -> bool:

--- a/polaris/polaris/templates/withdraw/form.html
+++ b/polaris/polaris/templates/withdraw/form.html
@@ -33,7 +33,7 @@
             </div>
             {% endfor %}
 
-            <table class="fee-table">
+            <table class="fee-table" hidden>
                 <tr class="fee-row"><td class="fee-label">{% trans "Fee" %}</td><td class="fee">{{ asset.symbol }}0</td></tr>
                 <tr class="amount-out-row"><td class="amount-out-label">{% trans "Total" %}</td><td class="amount-out">{{ asset.symbol }}0</td></tr>
             </table>

--- a/polaris/polaris/tests/conftest.py
+++ b/polaris/polaris/tests/conftest.py
@@ -114,12 +114,18 @@ def acc1_usd_deposit_transaction_factory(usd_asset_factory):
         stellar_account: str = STELLAR_ACCOUNT_1,
         protocol: str = Transaction.PROTOCOL.sep24,
     ):
+        if protocol in [Transaction.PROTOCOL.sep24, Transaction.PROTOCOL.sep6]:
+            status = Transaction.STATUS.pending_user_transfer_start
+            kind = Transaction.KIND.deposit
+        else:
+            status = Transaction.STATUS.pending_sender
+            kind = Transaction.KIND.send
         usd_asset = usd_asset_factory(protocols=[protocol])
         return Transaction.objects.create(
             stellar_account=stellar_account,
             asset=usd_asset,
-            kind=Transaction.KIND.deposit,
-            status=Transaction.STATUS.pending_user_transfer_start,
+            kind=kind,
+            status=status,
             status_eta=3600,
             external_transaction_id=(
                 "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093"

--- a/polaris/polaris/tests/processes/test_poll_pending_deposits.py
+++ b/polaris/polaris/tests/processes/test_poll_pending_deposits.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, Mock
 
-from polaris.management.commands.poll_pending_deposits import Command, rdi, logger
+from polaris.management.commands.poll_pending_deposits import Command, rdi, rri, logger
 from polaris.models import Transaction
 
 test_module = "polaris.management.commands.poll_pending_deposits"
@@ -11,14 +11,14 @@ test_module = "polaris.management.commands.poll_pending_deposits"
 @patch(f"{test_module}.create_stellar_deposit", return_value=True)
 def test_poll_pending_deposits_success(client, acc1_usd_deposit_transaction_factory):
     transaction = acc1_usd_deposit_transaction_factory()
-    rdi.poll_pending_deposits = Mock(return_value=[transaction])
+    rri.poll_pending_deposits = Mock(return_value=[transaction])
     rdi.after_deposit = Mock()
     Command.execute_deposits()
     transaction.refresh_from_db()
     assert transaction.status == Transaction.STATUS.pending_anchor
     assert transaction.status_eta == 5
     assert rdi.after_deposit.was_called
-    assert rdi.poll_pending_deposits.was_called
+    assert rri.poll_pending_deposits.was_called
 
 
 @pytest.mark.django_db
@@ -31,7 +31,7 @@ def test_poll_pending_deposits_bad_integration(
     acc1_usd_deposit_transaction_factory()
     # integration returns withdraw transaction
     withdrawal_transaction = acc1_usd_withdrawal_transaction_factory()
-    rdi.poll_pending_deposits = Mock(return_value=[withdrawal_transaction])
+    rri.poll_pending_deposits = Mock(return_value=[withdrawal_transaction])
     # error message is logged
     logger.error = Mock()
 

--- a/polaris/polaris/tests/sep31/test_transaction.py
+++ b/polaris/polaris/tests/sep31/test_transaction.py
@@ -35,7 +35,7 @@ def test_successful_call(client, acc1_usd_deposit_transaction_factory):
         == {
             "transaction": {
                 "id": str(transaction.id),
-                "status": "pending_user_transfer_start",
+                "status": "pending_sender",
                 "status_eta": 3600,
                 "amount_in": "18.34",
                 "amount_out": "18.24",

--- a/polaris/polaris/tests/sep6/test_withdraw.py
+++ b/polaris/polaris/tests/sep6/test_withdraw.py
@@ -21,9 +21,6 @@ class GoodWithdrawalIntegration(WithdrawalIntegration):
             raise ValueError()
         return {"extra_info": {"test": "test"}}
 
-    def process_withdrawal(self, response: Dict, transaction: Transaction):
-        pass
-
 
 @pytest.mark.django_db
 @patch("polaris.sep6.withdraw.rwi", GoodWithdrawalIntegration())
@@ -127,9 +124,6 @@ class MissingHowDepositIntegration(WithdrawalIntegration):
     def process_sep6_request(self, params: Dict) -> Dict:
         return {}
 
-    def process_withdrawal(self, response: Dict, transaction: Transaction):
-        pass
-
 
 @pytest.mark.django_db
 @patch("polaris.sep6.withdraw.rwi", MissingHowDepositIntegration())
@@ -166,9 +160,6 @@ def test_withdraw_empty_integration_response(
 class BadExtraInfoWithdrawalIntegration(WithdrawalIntegration):
     def process_sep6_request(self, params: Dict) -> Dict:
         return {"extra_info": "not a dict"}
-
-    def process_withdrawal(self, response: Dict, transaction: Transaction):
-        pass
 
 
 @pytest.mark.django_db
@@ -280,9 +271,6 @@ class GoodInfoNeededWithdrawalIntegration(WithdrawalIntegration):
             "type": "non_interactive_customer_info_needed",
             "fields": ["first_name", "last_name"],
         }
-
-    def process_withdrawal(self, response: Dict, transaction: Transaction):
-        pass
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR makes breaking changes to the API provided by Polaris' integration classes and functions

**Rails-related Functions:**

First, I moved `DepositIntegration.poll_pending_deposits` to `RailsIntegration.poll_pending_deposits`. I'm considering renaming this function to `poll_incoming_transactions` to match the newly added process `poll_outgoing_transactions`.

The reason to move this function is simple. Not every deposit into the anchor's external accounts are for SEP-6 or SEP-24. For example, a SEP-31 sending anchor can expect users to send them money so they can forward those funds to a receiver. Polaris does not support being a SEP-31 sending anchor, but it could in the future. The point is that SEP-6 and SEP-24 don't have a monopoly on an anchor's incoming non-stellar transactions, and all rails-related functions should be on `RailsIntegration` anyway.

Secondly, I removed `WithdrawalIntegration.process_withdrawal` and added support for SEP-6 and SEP-24 withdraw transactions going through `execute_outgoing_transactions()`, which is currently a SEP-31-only integration. The expectation is that the anchor transfers the funds from their stellar account to the user's off-chain account.

These two functions, `process_withdrawal()` and `execute_outgoing_transactions()`, serve the same purpose. The difference is that `process_withdrawal()` was, like `poll_pending_deposits()`, tied to the SEP-6 and SEP-24 integration classes. Since transferring assets off-chain is not exclusive to SEP-6 and SEP-24, this change needed to be made.