### PR TITLE
Fee integration changes

### DIFF
--- a/polaris/polaris/integrations/fees.py
+++ b/polaris/polaris/integrations/fees.py
@@ -37,9 +37,14 @@ def calculate_fee(fee_params: Dict) -> Decimal:
     if fee_params["operation"] == settings.OPERATION_WITHDRAWAL:
         fee_percent = asset.withdrawal_fee_percent
         fee_fixed = asset.withdrawal_fee_fixed
-    else:
+    elif fee_params["operation"] == settings.OPERATION_DEPOSIT:
         fee_percent = asset.deposit_fee_percent
         fee_fixed = asset.deposit_fee_fixed
+    elif fee_params["operation"] == "send":
+        fee_percent = asset.send_fee_percent
+        fee_fixed = asset.send_fee_fixed
+    else:
+        raise ValueError("invalid 'operation'")
 
     return round(
         fee_fixed + (fee_percent / Decimal("100") * amount), asset.significant_decimals,

--- a/polaris/polaris/integrations/fees.py
+++ b/polaris/polaris/integrations/fees.py
@@ -9,26 +9,28 @@ def calculate_fee(fee_params: Dict) -> Decimal:
     """
     .. _`/fee`: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#fee
 
-    Replace this function with another by passing it to
-    ``register_integrations()`` as described in
-    :doc:`Registering Integrations</register_integrations/index>`.
-
-    If this function is replaced with your own, `/info` responses will no
-    longer contain the `fee_fixed` and `fee_percent` attributes per-asset.
-    This is because Polaris can no longer assume fees are determined using
-    those attributes alone.
-
     Calculate the fee to be charged for the transaction described by `fee_params`.
 
-    `fee_params` will always contain the following key-value pairs: `amount`,
-    `asset_code`, and `operation`. Each of these key-value pairs correspond to
-    the associated parameter for the `/fee`_ endpoint.
+    Replace this function with another by passing it to
+    ``register_integrations()`` as described in
+    :doc:`Registering Integrations</register_integrations/index>` if the fees
+    charged for transactions is not calculated using the asset's ``fee_fixed``
+    and ``fee_percent`` attributes.
 
-    Additionally, `fee_params` may include a `type` key if this function is
-    called from the `/fee`_ API view. If this function is called from an
-    interactive flow's ``TransactionForm`` submission, `fee_params` will also
-    include any key-value pairs from `form.cleaned_data`. This allows anchors to
-    use the fields collected via their TransactionForm in fee calculation.
+    If replaced, `/info` responses will no longer contain the ``fee_fixed`` and
+    ``fee_percent`` attributes per-asset. This is because Polaris can no longer
+    assume fees are determined using those attributes alone.
+
+    `fee_params` will always contain the following key-value pairs:
+
+    - `amount`: ``Decimal``
+    - `asset_code`: ``str``
+    - `operation`: ``str``
+    - `type`: ``str``
+
+    Each of these key-value pairs correspond to the associated parameter for the
+    `/fee`_ endpoint. The Decimal returned will be used as the `fee` value in the
+    response.
     """
     amount = fee_params["amount"]
     asset = Asset.objects.filter(code=fee_params["asset_code"]).first()

--- a/polaris/polaris/sep24/deposit.py
+++ b/polaris/polaris/sep24/deposit.py
@@ -112,13 +112,7 @@ def post_interactive_deposit(request: Request) -> Response:
 
     if form.is_valid():
         if issubclass(form.__class__, TransactionForm):
-            fee_params = {
-                "operation": settings.OPERATION_DEPOSIT,
-                "asset_code": asset.code,
-                **form.cleaned_data,
-            }
             transaction.amount_in = form.cleaned_data["amount"]
-            transaction.amount_fee = registered_fee_func(fee_params)
             transaction.save()
 
         rdi.after_form_validation(form, transaction)

--- a/polaris/polaris/sep24/withdraw.py
+++ b/polaris/polaris/sep24/withdraw.py
@@ -109,13 +109,7 @@ def post_interactive_withdraw(request: Request) -> Response:
 
     elif form.is_valid():
         if issubclass(form.__class__, TransactionForm):
-            fee_params = {
-                "operation": settings.OPERATION_WITHDRAWAL,
-                "asset_code": asset.code,
-                **form.cleaned_data,
-            }
             transaction.amount_in = form.cleaned_data["amount"]
-            transaction.amount_fee = registered_fee_func(fee_params)
             transaction.save()
 
         rwi.after_form_validation(form, transaction)


### PR DESCRIPTION
**Fee Calculation and Integration**

This change involves transferring the responsibility of calculating `transaction.amount_fee` from Polaris to the anchor. Currently, Polaris makes the call to the registered fee function whenever the client passes a transaction's `amount`. This is ultimately unneeded and complicates fee calculation when the amount actually sent to the anchor differs from the amount originally specified in a API request.

Instead, we can simply require the anchor to calculate `transaction.amount_fee` whenever funds have been sent to the anchor, and the anchor needs to send funds (either off or on chain) to a user.

Specifically, we can require anchors to assign `transaction.amount_fee` in the following integration functions:
- `poll_pending_deposits` when the user sends money off-chain to be deposited on-chain
- `execute_outgoing_transactions` when the anchor has received stellar funds that need to be sent off-chain

This is where removing `process_withdrawal()` (in a previous PR) is nice. There's one less function to calculate the fee in. If users don't update `amount_fee` in those functions AND they have not overridden the default fee calculation function, Polaris can calculate the fee for them using the `fee_fixed` and `fee_percent` values associated with the asset.

Another advantage to this is that the registered fee integration function will only be called when requests to the `/fee` endpoint is made. This makes the fee integration function required only if you have a complex fee, and simplifies the fee integration function signature.