### PR TITLE
Remove PROJECT_ROOT setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,11 +75,12 @@ by adding `corsheaders signal`_ that checks the request URI. However this
 does not change the CORS policy for any other endpoint on the server. You can change
 this functionality using the settings listed in the `corsheaders documentation`_.
 
-Define ``PROJECT_ROOT`` in your project's settings.py. Polaris uses this to
-find your ``.env`` file.
+Ensure ``BASE_DIR`` is defined in your project's settings.py. Django adds this setting
+automatically. Polaris uses this to find your ``.env`` file. If this setting isn't present,
+Polaris will try to use the ``ENV_PATH`` setting. It should be the path to the ``.env`` file.
 ::
 
-    PROJECT_ROOT = "<path to directory containing .env file>"
+    BASE_DIR = "<path to your django project's top-level directory>"
 
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,17 +73,18 @@ by adding `corsheaders signal`_ that checks the request URI. However this
 does not change the CORS policy for any other endpoint on the server. You can change
 this functionality using the settings listed in the `corsheaders documentation`_.
 
-Define ``PROJECT_ROOT`` in your project's settings.py. Polaris uses this to
-find your ``.env`` file.
+Ensure ``BASE_DIR`` is defined in your project's settings.py. Django adds this setting
+automatically. Polaris uses this to find your ``.env`` file. If this setting isn't present,
+Polaris will try to use the ``ENV_PATH`` setting. It should be the path to the ``.env`` file.
 ::
 
-    PROJECT_ROOT = "<path to directory containing .env file>"
+    BASE_DIR = "<path to your django project's top-level directory>"
 
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
 Polaris uses environment variables that should be defined in the
-environment or included in ``PROJECT_ROOT/.env``.
+environment or included in ``BASE_DIR/.env`` or ``ENV_PATH``.
 ::
 
     STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"

--- a/example/server/settings.py
+++ b/example/server/settings.py
@@ -7,11 +7,10 @@ from django.utils.translation import gettext_lazy as _
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-PROJECT_ROOT = BASE_DIR
 
 # Load environment variables from .env
 env = environ.Env()
-env_file = os.path.join(PROJECT_ROOT, ".env")
+env_file = os.path.join(BASE_DIR, ".env")
 if os.path.exists(env_file):
     environ.Env.read_env(env_file)
 
@@ -88,7 +87,7 @@ WSGI_APPLICATION = "server.wsgi.application"
 DATABASES = {
     "default": env.db(
         "DATABASE_URL",
-        default="sqlite:///" + os.path.join(PROJECT_ROOT, "data/db.sqlite3"),
+        default="sqlite:///" + os.path.join(BASE_DIR, "data/db.sqlite3"),
     )
 }
 

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -10,11 +10,11 @@ from stellar_sdk.keypair import Keypair
 
 
 env = environ.Env()
-env_file = os.path.join(settings.BASE_DIR, ".env")
+env_file = os.path.join(getattr(settings, "BASE_DIR", ""), ".env")
 if os.path.exists(env_file):
     env.read_env(env_file)
-elif os.path.exists(settings.ENV_PATH):
-    env.read_env(env_file)
+elif hasattr(settings, "ENV_PATH") and os.path.exists(settings.ENV_PATH):
+    env.read_env(settings.ENV_PATH)
 
 SIGNING_SEED, SIGNING_KEY = None, None
 if "sep-10" in settings.ACTIVE_SEPS:

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -10,9 +10,11 @@ from stellar_sdk.keypair import Keypair
 
 
 env = environ.Env()
-env_file = os.path.join(settings.PROJECT_ROOT, ".env")
+env_file = os.path.join(settings.BASE_DIR, ".env")
 if os.path.exists(env_file):
-    environ.Env.read_env(str(env_file))
+    env.read_env(env_file)
+elif os.path.exists(settings.ENV_PATH):
+    env.read_env(env_file)
 
 SIGNING_SEED, SIGNING_KEY = None, None
 if "sep-10" in settings.ACTIVE_SEPS:

--- a/polaris/settings.py
+++ b/polaris/settings.py
@@ -7,11 +7,10 @@ import environ
 from django.utils.translation import gettext_lazy as _
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT = BASE_DIR
 
 # Load environment variables from .env
 env = environ.Env()
-env_file = os.path.join(PROJECT_ROOT, ".env")
+env_file = os.path.join(BASE_DIR, ".env")
 if os.path.exists(env_file):
     environ.Env.read_env(env_file)
 
@@ -81,7 +80,7 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 DATABASES = {
     "default": env.db(
-        "DATABASE_URL", default="sqlite:////" + os.path.join(PROJECT_ROOT, "db.sqlite3")
+        "DATABASE_URL", default="sqlite:////" + os.path.join(BASE_DIR, "db.sqlite3")
     )
 }
 


### PR DESCRIPTION
resolves stellar/django-polaris#235

Simplifies setup by using an autogenerated settting Django creates. Also adds the optional `ENV_PATH` setting which is a absolute path to the environment file.