### PR TITLE
Split content_for_transaction() into two functions

### DIFF
--- a/docs/sep6_and_sep24/index.rst
+++ b/docs/sep6_and_sep24/index.rst
@@ -76,16 +76,16 @@ The last step is to collect the static files Polaris provides into your app:
 Replacing Polaris UI Assets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Its also possible to replace the static assets from Polaris. This allows anchors
-to customize the UI's appearance. One asset you will surely want to replace is the Stellar
-icon displayed at the top of each page.
+.. _here: https://github.com/stellar/django-polaris/tree/master/polaris/polaris/static/polaris
 
-To replace this with your own icon, put a file within your static directory under the
-path `polaris/company-icon.svg`. The django app containing this file must be listed
-in ``INSTALLED_APPS`` `above` ``"polaris"`` in order for django to use it.
+Its also possible to replace the static assets from Polaris. This allows anchors
+to customize the UI's appearance. For example, you can replace Polaris' `base.css`
+file to give the interactive flow pages a different look. You can do this by adding
+your own `polaris/base.css` file to your app's static directory.
 
 In general, replacement asset files (.html, .css, etc.) must have the same path and
-name of the file its replacing.
+name of the file its replacing. See the structure of Polaris' static assets
+directory here_.
 
 See the documentation on `serving static files`_ in Django for more information.
 
@@ -199,11 +199,15 @@ more information.
 
 The functions below facilitate the process of collecting the information needed.
 
-.. autofunction:: polaris.integrations.DepositIntegration.content_for_transaction
+.. autofunction:: polaris.integrations.DepositIntegration.form_for_transaction
+
+.. autofunction:: polaris.integrations.DepositIntegration.content_for_template
 
 .. autofunction:: polaris.integrations.DepositIntegration.after_form_validation
 
-.. autofunction:: polaris.integrations.WithdrawalIntegration.content_for_transaction
+.. autofunction:: polaris.integrations.WithdrawalIntegration.form_for_transaction
+
+.. autofunction:: polaris.integrations.DepositIntegration.content_for_template
 
 .. autofunction:: polaris.integrations.WithdrawalIntegration.after_form_validation
 

--- a/polaris/polaris/integrations/forms.py
+++ b/polaris/polaris/integrations/forms.py
@@ -80,7 +80,7 @@ class TransactionForm(forms.Form):
     apply additional validation.
 
     A subclass of this form should be returned by
-    ``content_for_transaction()`` once for each interactive flow.
+    ``form_for_transaction()`` once for each interactive flow.
 
     After form validation, the key-value pairs in `self.cleaned_data` will be
     passed to the registered fee function to calculate `amount_fee` for the

--- a/polaris/polaris/integrations/javascript.py
+++ b/polaris/polaris/integrations/javascript.py
@@ -18,10 +18,9 @@ def scripts(page_content: Optional[Dict]) -> List[str]:
             {{ script|safe }}
         {% endfor %}
 
-    `page_content` will be the return value from ``content_for_transaction()``
-    for requests during the interactive flow and ``None`` for requests to the
-    `/more_info` endpoint. Anchors can
-    use `page_content` to determine which scripts need to be rendered.
+    `page_content` will be the return value from ``content_for_template()``.
+    `page_content` will also contain a ``"form"`` key-value pair if a form
+    will be rendered in the UI.
 
     This gives anchors a great deal of freedom on the client side. The
     `example reference server`_ uses this functionality to inject Google

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -166,8 +166,8 @@ class DepositIntegration:
         """
         Use this function to process the data collected with `form` and to update
         the state of the interactive flow so that the next call to
-        ``DepositIntegration.content_for_transaction`` returns a dictionary
-        containing the next form to render to the user, or returns None.
+        ``DepositIntegration.form_for_transaction`` returns the next form to render
+        to the user, or returns None.
 
         Keep in mind that if a ``TransactionForm`` is submitted, Polaris will
         update the `amount_in` and `amount_fee` with the information collected.
@@ -178,7 +178,7 @@ class DepositIntegration:
         particular values at different points in the flow.
 
         If you need to store some data to determine which form to return next when
-        ``DepositIntegration.content_for_transaction`` is called, store this
+        ``DepositIntegration.form_for_transaction`` is called, store this
         data in a model not used by Polaris.
 
         :param form: the completed ``forms.Form`` submitted by the user
@@ -219,7 +219,7 @@ class DepositIntegration:
     def save_sep9_fields(self, stellar_account: str, fields: Dict, language_code: str):
         """
         Save the `fields` passed for `stellar_account` to pre-populate the forms returned
-        from ``content_for_transaction()``. Note that this function is called before
+        from ``form_for_transaction()``. Note that this function is called before
         the transaction is created.
 
         For example, you could save the user's contact information with the model used
@@ -236,16 +236,13 @@ class DepositIntegration:
         saved in this method relevant to that form.
         ::
 
-            # In your content_for_transaction() implementation
+            # In your form_for_transaction() implementation
             user = user_for_account(transaction.stellar_account)
             form_args = {
                 'phone_number': format_number(user.phone_number),
                 'email': user.email_address
             }
-            return {
-                'form': KYCForm(initial=form_args),
-                'title': "KYC Collection"
-            }
+            return KYCForm(initial=form_args),
 
         If you'd like to validate the values passed in `fields`, you can perform any necessary
         checks and raise a ``ValueError`` in this function. Polaris will return the message of

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -38,8 +38,8 @@ class DepositIntegration:
         amount: Optional[Decimal] = None,
     ) -> Optional[forms.Form]:
         """
-        This function should the next form to render for the user given the state of
-        the interactive flow.
+        This function should return the next form to render for the user given the
+        state of the interactive flow.
 
         For example, this function could return an instance of a ``TransactionForm``
         subclass. Once the form is submitted, Polaris will detect the form used
@@ -112,7 +112,7 @@ class DepositIntegration:
         Return a dictionary containing page content to be used in the template passed for the
         given `form` and `transaction`.
 
-        Polaris will pass one of the following ``polaris.templates.Template` values:
+        Polaris will pass one of the following ``polaris.templates.Template`` values:
 
         * Template.DEPOSIT
 

--- a/polaris/polaris/sep24/withdraw.py
+++ b/polaris/polaris/sep24/withdraw.py
@@ -57,15 +57,15 @@ def post_interactive_withdraw(request: Request) -> Response:
     flow. The following steps are taken during this process:
 
         1. URL arguments are parsed and validated.
-        2. content_for_transaction() is called to retrieve the form used to
+        2. form_for_transaction() is called to retrieve the form used to
            submit this request. This function is implemented by the anchor.
         3. The form is used to validate the data submitted, and if the form
            is a TransactionForm, the fee for the transaction is calculated.
         4. after_form_validation() is called to allow the anchor to process
            the data submitted. This function should change the application
-           state such that the next call to content_for_transaction() returns
+           state such that the next call to form_for_transaction() returns
            the next form in the flow.
-        5. content_for_transaction() is called again to retrieve the next
+        5. form_for_transaction() is called again to retrieve the next
            form to be served to the user. If a form is returned, the
            function redirects to GET /transaction/deposit/webapp. Otherwise,
            The user's session is invalidated, the transaction status is
@@ -86,8 +86,7 @@ def post_interactive_withdraw(request: Request) -> Response:
     )
     if not form:
         logger.error(
-            "Initial content_for_transaction() call returned None "
-            f"for {transaction.id}"
+            "Initial form_for_transaction() call returned None " f"for {transaction.id}"
         )
         if transaction.status != transaction.STATUS.incomplete:
             return render_error_response(
@@ -155,7 +154,7 @@ def post_interactive_withdraw(request: Request) -> Response:
             return redirect(f"{url}?{args}")
 
     else:
-        scripts = registered_scripts_func(content)
+        scripts = registered_scripts_func({"form": form, **content})
 
         url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
         if callback:
@@ -223,7 +222,7 @@ def get_interactive_withdraw(request: Request) -> Response:
            returned, this function redirects to the URL. However, the session
            cookie should still be included in the response so future calls to
            GET /transactions/withdraw/interactive/complete are authenticated.
-        3. content_for_transaction() is called to retrieve the next form to
+        3. form_for_transaction() is called to retrieve the next form to
            render to the user.
         4. get and post URLs are constructed with the appropriate arguments
            and passed to the response to be rendered to the user.
@@ -263,7 +262,7 @@ def get_interactive_withdraw(request: Request) -> Response:
     elif content is None:
         content = {}
 
-    scripts = registered_scripts_func(content)
+    scripts = registered_scripts_func({"form": form, **content})
 
     url_args = {"transaction_id": transaction.id, "asset_code": asset.code}
     if callback:

--- a/polaris/polaris/shared/endpoints.py
+++ b/polaris/polaris/shared/endpoints.py
@@ -44,7 +44,6 @@ def more_info(request: Request, sep6: bool = False) -> Response:
         "amount_fee": serializer.data.get("amount_fee"),
         "transaction": request_transaction,
         "asset_code": request_transaction.asset.code,
-        "scripts": registered_scripts_func(None),
     }
     if request_transaction.kind == Transaction.KIND.deposit:
         content = rdi.content_for_template(
@@ -59,6 +58,7 @@ def more_info(request: Request, sep6: bool = False) -> Response:
             Template.MORE_INFO, transaction=request_transaction
         )
 
+    resp_data["scripts"] = registered_scripts_func(content)
     if content:
         resp_data.update(content)
 

--- a/polaris/polaris/templates/__init__.py
+++ b/polaris/polaris/templates/__init__.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class Template(enum.Enum):
+    MORE_INFO = 1
+    DEPOSIT = 2
+    WITHDRAW = 3

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -271,7 +271,7 @@ def test_interactive_auth_new_transaction(client, acc1_usd_deposit_transaction_f
     were not authenticated for the specified transaction.
     """
     deposit = acc1_usd_deposit_transaction_factory()
-    # So that content_for_transaction() returns TransactionForm
+    # So that form_for_transaction() returns TransactionForm
     deposit.amount_in = None
     deposit.save()
 


### PR DESCRIPTION
resolves stellar/django-polaris#233

`content_for_transaction()`, an integration function for both `DepositIntegration` and `WithdrawalIntegration`, is an important piece of Polaris' SEP-24 support. With it, anchors return the form they want to present to the user _and_ additional page content, such as the icon, its label, and guidance for the user.

For example:
![Screen Shot 2020-07-21 at 12 10 58 PM](https://user-images.githubusercontent.com/10968980/88096310-493de400-cb4b-11ea-8506-4995f7f350b2.png)

_"Stellar Development Foundation"_ is the label string returned from the reference server's `content_for_transaction()` function.

_"Please enter the amount you would like to transfer."_ is also guidance from that function.

This type of content, specifically a page title, icon, and icon label, is also needed in the more info page. But `content_for_transaction()` isn't called when requests for the more info page are made. The function is only called during the interactive flow to collect the next form to serve.

To make sure the anchor can provide content for the more info page, we'll split `content_for_transaction()` into two new functions, `form_for_transaction()` and `content_for_template()`. `form_for_transaction()` is only called during the interactive flow and only returns the form to serve. `content_for_template()` is called whenever Polaris should return an HTML page.