### PR TITLE
Include SEP-31 transaction in query for last successful TX received

### DIFF
--- a/polaris/polaris/management/commands/watch_transactions.py
+++ b/polaris/polaris/management/commands/watch_transactions.py
@@ -66,9 +66,10 @@ class Command(BaseCommand):
                 )
             last_completed_transaction = (
                 Transaction.objects.filter(
+                    Q(kind=Transaction.KIND.withdrawal)
+                    | Q(kind=Transaction.KIND.send),
                     receiving_anchor_account=account,
                     status=Transaction.STATUS.completed,
-                    kind=Transaction.KIND.withdrawal,
                 )
                 .order_by("-completed_at")
                 .first()


### PR DESCRIPTION
resolves stellar/django-polaris#254

Polaris has several other processes that perform necessary functions.

When the `watch_transactions` process is down, clients can still make payments to the anchor's distribution account on Stellar. In order to ensure we don't miss a payment, we start stream payment transactions starting at the time of the last successfully processed payment transaction whenever `watch_transactions` is started.

We should include SEP-31 payments in this query for the most recent TX. Currently, its possible to miss transactions if the anchor only supports SEP-31.