### PR TITLE
Pass transaction to process_sep6_request integration functions

### DIFF
--- a/example/server/integrations.py
+++ b/example/server/integrations.py
@@ -226,7 +226,7 @@ class MyDepositIntegration(DepositIntegration):
                 f"{transaction.stellar_account}"
             )
 
-    def process_sep6_request(self, params: Dict) -> Dict:
+    def process_sep6_request(self, params: Dict, transaction: Transaction) -> Dict:
         qparams = {"account": params["account"], "memo": None}
         account = (
             PolarisStellarAccount.objects.filter(**qparams)
@@ -259,7 +259,10 @@ class MyDepositIntegration(DepositIntegration):
             # the flow since this is a reference server.
             pass
 
-        # request is valid, return success data
+        # request is valid, return success data and add transaction to user model
+        PolarisUserTransaction.objects.create(
+            transaction_id=transaction.id, user=account.user, account=account
+        )
         return {
             "how": "fake bank account number",
             "extra_info": {
@@ -325,7 +328,7 @@ class MyWithdrawalIntegration(WithdrawalIntegration):
                 f"{transaction.stellar_account}"
             )
 
-    def process_sep6_request(self, params: Dict) -> Dict:
+    def process_sep6_request(self, params: Dict, transaction: Transaction) -> Dict:
         qparams = {"account": params["account"], "memo": None}
         account = (
             PolarisStellarAccount.objects.filter(**qparams)
@@ -384,6 +387,9 @@ class MyWithdrawalIntegration(WithdrawalIntegration):
             response["memo_type"] = params["memo_type"]
             response["memo"] = params["memo"]
 
+        PolarisUserTransaction.objects.create(
+            transaction_id=transaction.id, user=account.user, account=account
+        )
         return response
 
 

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -251,7 +251,7 @@ class DepositIntegration:
         """
         pass
 
-    def process_sep6_request(self, params: Dict) -> Dict:
+    def process_sep6_request(self, params: Dict, transaction: Transaction) -> Dict:
         """
         .. _deposit: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#deposit
         .. _Deposit no additional information needed: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#1-success-no-additional-information-needed
@@ -259,12 +259,14 @@ class DepositIntegration:
         .. _Customer Information Status: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#4-customer-information-status
 
         Process the request arguments passed to the deposit_ endpoint and return one of the
-        following responses as a dictionary:
+        following responses outlined below as a dictionary. Save `transaction` to the DB
+        if you plan to return a success response. If `transaction` is saved to the DB but a
+        failure response is returned, Polaris will return a 500 error to the user.
 
         `Deposit no additional information needed`_
 
-        Polaris creates most of the attributes described in this response. Simply return the
-        'how' and optionally 'extra_info' attributes. For example:
+        The success response. Polaris creates most of the attributes described in this response.
+        Simply return the 'how' and optionally 'extra_info' attributes. For example:
         ::
 
             return {
@@ -276,7 +278,7 @@ class DepositIntegration:
 
         `Customer information needed`_
 
-        Return the response as described in SEP.
+        A failure response. Return the response as described in SEP.
         ::
 
             return {
@@ -286,9 +288,9 @@ class DepositIntegration:
 
         `Customer Information Status`_
 
-        Return the 'type' and 'status' attributes. If ``CustomerIntegration.more_info_url()``
-        is implemented, Polaris will include the 'more_info_url' attribute in the response as
-        well.
+        A failure response. Return the 'type' and 'status' attributes. If
+        ``CustomerIntegration.more_info_url()`` is implemented, Polaris will include the
+        'more_info_url' attribute in the response as well.
         ::
 
             return {
@@ -297,6 +299,8 @@ class DepositIntegration:
             }
 
         :param params: the request parameters as described in /deposit_
+        :param transaction: an unsaved ``Transaction`` object representing the transaction
+            to be processed
         """
         raise NotImplementedError(
             "`process_sep6_request` must be implemented if SEP-6 is active"
@@ -394,18 +398,20 @@ class WithdrawalIntegration:
         """
         pass
 
-    def process_sep6_request(self, params: Dict) -> Dict:
+    def process_sep6_request(self, params: Dict, transaction: Transaction) -> Dict:
         """
         .. _/withdraw: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#withdraw
         .. _Withdraw no additional information needed: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#1-success-no-additional-information-needed-1
 
         Process the request arguments passed to the `/withdraw`_ endpoint and return one of the
-        following responses as a dictionary:
+        following responses outlined below as a dictionary. Save `transaction` to the DB
+        if you plan to return a success response. If `transaction` is saved to the DB but a
+        failure response is returned, Polaris will return a 500 error to the user.
 
         `Withdraw no additional information needed`_
 
-        Polaris populates most of the attributes for this response. Simply return an 'extra_info'
-        attribute if applicable:
+        A success response. Polaris populates most of the attributes for this response.
+        Simply return an 'extra_info' attribute if applicable:
         ::
 
             {

--- a/polaris/polaris/management/commands/watch_transactions.py
+++ b/polaris/polaris/management/commands/watch_transactions.py
@@ -66,8 +66,7 @@ class Command(BaseCommand):
                 )
             last_completed_transaction = (
                 Transaction.objects.filter(
-                    Q(kind=Transaction.KIND.withdrawal)
-                    | Q(kind=Transaction.KIND.send),
+                    Q(kind=Transaction.KIND.withdrawal) | Q(kind=Transaction.KIND.send),
                     receiving_anchor_account=account,
                     status=Transaction.STATUS.completed,
                 )

--- a/polaris/polaris/sep6/deposit.py
+++ b/polaris/polaris/sep6/deposit.py
@@ -56,7 +56,9 @@ def deposit(account: str, request: Request) -> Response:
         return render_error_response(str(e))
 
     try:
-        response, status_code = validate_response(args, integration_response)
+        response, status_code = validate_response(
+            args, integration_response, transaction
+        )
     except (ValueError, KeyError):
         return render_error_response(
             _("unable to process the request"), status_code=500
@@ -74,14 +76,16 @@ def deposit(account: str, request: Request) -> Response:
     return Response(response, status=status_code)
 
 
-def validate_response(args: Dict, integration_response: Dict) -> Tuple[Dict, int]:
+def validate_response(
+    args: Dict, integration_response: Dict, transaction: Transaction
+) -> Tuple[Dict, int]:
     """
     Validate /deposit response returned from integration function
     """
     account = args["account"]
     asset = args["asset"]
     if "type" in integration_response:
-        return validate_403_response(account, integration_response), 403
+        return validate_403_response(account, integration_response, transaction), 403
 
     response = {
         "min_amount": round(asset.deposit_min_amount, asset.significant_decimals),

--- a/polaris/polaris/sep6/withdraw.py
+++ b/polaris/polaris/sep6/withdraw.py
@@ -38,12 +38,28 @@ def withdraw(account: str, request: Request) -> Response:
         return args["error"]
     args["account"] = account
 
+    transaction_id = create_transaction_id()
+    transaction_id_hex = transaction_id.hex
+    padded_hex_memo = "0" * (64 - len(transaction_id_hex)) + transaction_id_hex
+    memo = memo_hex_to_base64(padded_hex_memo)
+    transaction = Transaction(
+        id=transaction_id,
+        stellar_account=account,
+        asset=args["asset"],
+        kind=Transaction.KIND.withdrawal,
+        status=Transaction.STATUS.pending_user_transfer_start,
+        receiving_anchor_account=args["asset"].distribution_account,
+        memo=memo,
+        memo_type=Transaction.MEMO_TYPES.hash,
+        protocol=Transaction.PROTOCOL.sep6,
+    )
+
     # All request arguments are validated in parse_request_args()
     # except 'type', 'dest', and 'dest_extra'. Since Polaris doesn't know
     # which argument was invalid, the anchor is responsible for raising
     # an exception with a translated message.
     try:
-        integration_response = rwi.process_sep6_request(args)
+        integration_response = rwi.process_sep6_request(args, transaction)
     except ValueError as e:
         return render_error_response(str(e))
     try:
@@ -54,24 +70,15 @@ def withdraw(account: str, request: Request) -> Response:
         )
 
     if status_code == 200:
-        transaction_id = create_transaction_id()
-        transaction_id_hex = transaction_id.hex
-        padded_hex_memo = "0" * (64 - len(transaction_id_hex)) + transaction_id_hex
-        memo = memo_hex_to_base64(padded_hex_memo)
-        Transaction.objects.create(
-            id=transaction_id,
-            stellar_account=account,
-            asset=args["asset"],
-            kind=Transaction.KIND.withdrawal,
-            status=Transaction.STATUS.pending_user_transfer_start,
-            receiving_anchor_account=args["asset"].distribution_account,
-            memo=memo,
-            memo_type=Transaction.MEMO_TYPES.hash,
-            protocol=Transaction.PROTOCOL.sep6,
-        )
         response["memo"] = memo
         response["memo_type"] = Transaction.MEMO_TYPES.hash
         logger.info(f"Created withdraw transaction {transaction_id}")
+        transaction.save()
+    elif Transaction.objects.filter(id=transaction.id).exists():
+        logger.error("Do not save transaction objects for invalid SEP-6 requests")
+        return render_error_response(
+            _("unable to process the request"), status_code=500
+        )
 
     return Response(response, status=status_code)
 

--- a/polaris/polaris/sep6/withdraw.py
+++ b/polaris/polaris/sep6/withdraw.py
@@ -63,7 +63,9 @@ def withdraw(account: str, request: Request) -> Response:
     except ValueError as e:
         return render_error_response(str(e))
     try:
-        response, status_code = validate_response(args, integration_response)
+        response, status_code = validate_response(
+            args, integration_response, transaction
+        )
     except ValueError:
         return render_error_response(
             _("unable to process the request"), status_code=500
@@ -123,11 +125,13 @@ def parse_request_args(request: Request) -> Dict:
     }
 
 
-def validate_response(args: Dict, integration_response: Dict) -> Tuple[Dict, int]:
+def validate_response(
+    args: Dict, integration_response: Dict, transaction: Transaction
+) -> Tuple[Dict, int]:
     account = args["account"]
     asset = args["asset"]
     if "type" in integration_response:
-        return validate_403_response(account, integration_response), 403
+        return validate_403_response(account, integration_response, transaction), 403
 
     response = {
         "account_id": asset.distribution_account,


### PR DESCRIPTION
resolves stellar/django-polaris#247

As described in the issue, this change passes the `Transaction` object to `process_sep6_request()`, which allows the developer to link the transaction created as a result of the request to the rest of the anchor's data model.

I'll also be updating SEP-31's `process_send_request()` integration function to pass the `Transaction` object instead of the id to match this solution.