### PR TITLE
Prepend Polaris-specific settings with 'POLARIS_'

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,7 +78,7 @@ this functionality using the settings listed in the `corsheaders documentation`_
 
 Ensure ``BASE_DIR`` is defined in your project's settings.py. Django adds this setting
 automatically. Polaris uses this to find your ``.env`` file. If this setting isn't present,
-Polaris will try to use the ``ENV_PATH`` setting. It should be the path to the ``.env`` file.
+Polaris will try to use the ``POLARIS_ENV_PATH`` setting. It should be the path to the ``.env`` file.
 ::
 
     BASE_DIR = "<path to your django project's top-level directory>"
@@ -87,7 +87,7 @@ Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
 Polaris uses environment variables that should be defined in the
-environment or included in ``BASE_DIR/.env`` or ``ENV_PATH``.
+environment or included in ``BASE_DIR/.env`` or ``POLARIS_ENV_PATH``.
 ::
 
     STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"

--- a/docs/sep1/index.rst
+++ b/docs/sep1/index.rst
@@ -5,10 +5,10 @@ SEP-1
 Configuration
 -------------
 
-Simply add the SEP to your ``ACTIVE_SEPS`` list in settings.py:
+Simply add the SEP to your ``POLARIS_ACTIVE_SEPS`` list in settings.py:
 ::
 
-    ACTIVE_SEPS = ["sep-1", "sep-10", ...]
+    POLARIS_ACTIVE_SEPS = ["sep-1", "sep-10", ...]
 
 .. _sep1_integrations:
 

--- a/docs/sep10/index.rst
+++ b/docs/sep10/index.rst
@@ -21,7 +21,7 @@ transactions.
 Add SEP-10 to your list of active SEPs in settings.py:
 ::
 
-    ACTIVE_SEPS = ["sep-1", "sep-10", ...]
+    POLARIS_ACTIVE_SEPS = ["sep-1", "sep-10", ...]
 
 
 Integrations

--- a/docs/sep12/index.rst
+++ b/docs/sep12/index.rst
@@ -9,10 +9,10 @@ SEP-12
 Configuration
 -------------
 
-Simply add the SEP to your ``ACTIVE_SEPS`` list in settings.py:
+Simply add the SEP to your ``POLARIS_ACTIVE_SEPS`` list in settings.py:
 ::
 
-    ACTIVE_SEPS = ["sep-1", "sep-12", ...]
+    POLARIS_ACTIVE_SEPS = ["sep-1", "sep-12", ...]
 
 Integrations
 ------------

--- a/docs/sep31/index.rst
+++ b/docs/sep31/index.rst
@@ -17,10 +17,10 @@ SEP-31 anchor.
 Configuration
 =============
 
-Add the SEP to ``ACTIVE_SEPS`` in in your settings file.
+Add the SEP to ``POLARIS_ACTIVE_SEPS`` in in your settings file.
 ::
 
-    ACTIVE_SEPS = ["sep-1", "sep-10", "sep-31", ...]
+    POLARIS_ACTIVE_SEPS = ["sep-1", "sep-10", "sep-31", ...]
 
 Integrations
 ============

--- a/docs/sep6_and_sep24/index.rst
+++ b/docs/sep6_and_sep24/index.rst
@@ -25,10 +25,10 @@ and cons, so make sure you understand the proposals before choosing.
 Configuration
 =============
 
-Add the SEPs to ``ACTIVE_SEPS`` in in your settings file.
+Add the SEPs to ``POLARIS_ACTIVE_SEPS`` in in your settings file.
 ::
 
-    ACTIVE_SEPS = ["sep-1", "sep-6", "sep-24", ...]
+    POLARIS_ACTIVE_SEPS = ["sep-1", "sep-6", "sep-24", ...]
 
 .. _static_assets:
 

--- a/example/server/settings.py
+++ b/example/server/settings.py
@@ -39,7 +39,7 @@ INSTALLED_APPS = [
     "polaris",
 ]
 
-ACTIVE_SEPS = ["sep-1", "sep-6", "sep-10", "sep-12", "sep-24", "sep-31"]
+POLARIS_ACTIVE_SEPS = ["sep-1", "sep-6", "sep-10", "sep-12", "sep-24", "sep-31"]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/polaris/polaris/sep1/views.py
+++ b/polaris/polaris/sep1/views.py
@@ -29,16 +29,16 @@ def generate_toml(request):
         "NETWORK_PASSPHRASE": settings.STELLAR_NETWORK_PASSPHRASE,
     }
 
-    if "sep-24" in django_settings.ACTIVE_SEPS:
+    if "sep-24" in django_settings.POLARIS_ACTIVE_SEPS:
         toml_dict["TRANSFER_SERVER"] = os.path.join(settings.HOST_URL, "sep24")
         toml_dict["TRANSFER_SERVER_SEP0024"] = toml_dict["TRANSFER_SERVER"]
-    if "sep-6" in django_settings.ACTIVE_SEPS:
+    if "sep-6" in django_settings.POLARIS_ACTIVE_SEPS:
         toml_dict["TRANSFER_SERVER"] = os.path.join(settings.HOST_URL, "sep6")
-    if "sep-10" in django_settings.ACTIVE_SEPS:
+    if "sep-10" in django_settings.POLARIS_ACTIVE_SEPS:
         toml_dict["WEB_AUTH_ENDPOINT"] = os.path.join(settings.HOST_URL, "auth")
-    if "sep-12" in django_settings.ACTIVE_SEPS:
+    if "sep-12" in django_settings.POLARIS_ACTIVE_SEPS:
         toml_dict["KYC_SERVER"] = os.path.join(settings.HOST_URL, "kyc")
-    if "sep-31" in django_settings.ACTIVE_SEPS:
+    if "sep-31" in django_settings.POLARIS_ACTIVE_SEPS:
         toml_dict["DIRECT_PAYMENT_SERVER"] = os.path.join(settings.HOST_URL, "sep31")
 
     toml_dict.update(registered_toml_func())

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -13,16 +13,18 @@ env = environ.Env()
 env_file = os.path.join(getattr(settings, "BASE_DIR", ""), ".env")
 if os.path.exists(env_file):
     env.read_env(env_file)
-elif hasattr(settings, "ENV_PATH") and os.path.exists(settings.ENV_PATH):
-    env.read_env(settings.ENV_PATH)
+elif hasattr(settings, "POLARIS_ENV_PATH") and os.path.exists(
+    settings.POLARIS_ENV_PATH
+):
+    env.read_env(settings.POLARIS_ENV_PATH)
 
 SIGNING_SEED, SIGNING_KEY = None, None
-if "sep-10" in settings.ACTIVE_SEPS:
+if "sep-10" in settings.POLARIS_ACTIVE_SEPS:
     SIGNING_SEED = env("SIGNING_SEED")
     SIGNING_KEY = Keypair.from_secret(SIGNING_SEED).public_key
 
 SERVER_JWT_KEY = None
-if any(sep in settings.ACTIVE_SEPS for sep in ["sep-10", "sep-24"]):
+if any(sep in settings.POLARIS_ACTIVE_SEPS for sep in ["sep-10", "sep-24"]):
     SERVER_JWT_KEY = env("SERVER_JWT_KEY")
 
 STELLAR_NETWORK_PASSPHRASE = env(

--- a/polaris/polaris/urls.py
+++ b/polaris/polaris/urls.py
@@ -18,7 +18,7 @@ from django.urls import path, include
 
 
 urlpatterns = []
-active_seps = getattr(settings, "ACTIVE_SEPS")
+active_seps = getattr(settings, "POLARIS_ACTIVE_SEPS")
 if "sep-1" in active_seps:
     urlpatterns.append(path(".well-known/", include("polaris.sep1.urls")))
 

--- a/polaris/polaris/utils.py
+++ b/polaris/polaris/utils.py
@@ -377,14 +377,14 @@ def extract_sep9_fields(args):
 def check_config():
     from polaris.sep24.utils import check_sep24_config
 
-    if not hasattr(django_settings, "ACTIVE_SEPS"):
+    if not hasattr(django_settings, "POLARIS_ACTIVE_SEPS"):
         raise AttributeError(
-            "ACTIVE_SEPS must be defined in your django settings file."
+            "POLARIS_ACTIVE_SEPS must be defined in your django settings file."
         )
 
     check_middleware()
     check_protocol()
-    if "sep-24" in django_settings.ACTIVE_SEPS:
+    if "sep-24" in django_settings.POLARIS_ACTIVE_SEPS:
         check_sep24_config()
 
 

--- a/polaris/settings.py
+++ b/polaris/settings.py
@@ -42,7 +42,7 @@ third_party_apps.append("polaris")
 
 INSTALLED_APPS = django_apps + third_party_apps
 
-ACTIVE_SEPS = ["sep-1", "sep-6", "sep-10", "sep-12", "sep-24", "sep-31"]
+POLARIS_ACTIVE_SEPS = ["sep-1", "sep-6", "sep-10", "sep-12", "sep-24", "sep-31"]
 
 # Modules to add to parent project's MIDDLEWARE
 MIDDLEWARE = [


### PR DESCRIPTION
resolves stellar/django-polaris#253

The only two variables in `settings.py` Polaris looks for currently are `ENV_PATH` and `ACTIVE_SEPS`. When stellar/django-polaris#248 is implemented, Polaris will look in `settings.py` after checking the environment for the variables expected there. We'll have to update the functionality introduced here once that is merged.