### PR TITLE
Testnet CLI command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,7 +317,11 @@ this may be slower.
 
 Submit a PR
 ^^^^^^^^^^^
+.. _black: https://pypi.org/project/black/
+
 After you've made your changes, push them to you a remote branch
 and make a Pull Request on the stellar/django-polaris master branch.
+Note that Polaris user the `black`_ code formatter, so please format your
+code before requesting us to merge your changes.
 
 

--- a/example/server/integrations.py
+++ b/example/server/integrations.py
@@ -25,7 +25,7 @@ from polaris.integrations import (
     calculate_fee,
     RailsIntegration,
     TransactionForm,
-    TemplateScript
+    TemplateScript,
 )
 from polaris import settings
 
@@ -788,14 +788,17 @@ def scripts_integration(page_content: Optional[Dict]):
     scripts = [
         # Google Analytics
         # <!-- Global site tag (gtag.js) - Google Analytics -->
-        TemplateScript(url="https://www.googletagmanager.com/gtag/js?id=UA-53373928-6", is_async=True),
-        TemplateScript(path="sep24_scripts/google_analytics.js")
+        TemplateScript(
+            url="https://www.googletagmanager.com/gtag/js?id=UA-53373928-6",
+            is_async=True,
+        ),
+        TemplateScript(path="sep24_scripts/google_analytics.js"),
     ]
 
     if (
-        page_content and
-        "form" not in page_content and
-        page_content.get("title") == CONFIRM_EMAIL_PAGE_TITLE
+        page_content
+        and "form" not in page_content
+        and page_content.get("title") == CONFIRM_EMAIL_PAGE_TITLE
     ):
         # Refresh the confirm email page whenever the user brings the popup
         # back into focus. This is not strictly necessary since deposit.html
@@ -804,7 +807,9 @@ def scripts_integration(page_content: Optional[Dict]):
         # Add a "Skip Confirmation" button that will make a GET request to the
         # skip confirmation endpoint and reload the page. The email confirmation
         # functionality is just for sake of demonstration anyway.
-        scripts.append(TemplateScript(path="sep24_scripts/add_skip_confirmation_btn.js"))
+        scripts.append(
+            TemplateScript(path="sep24_scripts/add_skip_confirmation_btn.js")
+        )
 
     return scripts
 

--- a/polaris/polaris/integrations/__init__.py
+++ b/polaris/polaris/integrations/__init__.py
@@ -5,7 +5,9 @@ from polaris.integrations.fees import calculate_fee, registered_fee_func
 from polaris.integrations.forms import TransactionForm, CreditCardForm
 from polaris.integrations.toml import get_stellar_toml, registered_toml_func
 from polaris.integrations.javascript import (
-    scripts, registered_scripts_func, TemplateScript
+    scripts,
+    registered_scripts_func,
+    TemplateScript,
 )
 from polaris.integrations.customers import (
     CustomerIntegration,

--- a/polaris/polaris/integrations/javascript.py
+++ b/polaris/polaris/integrations/javascript.py
@@ -4,9 +4,13 @@ from typing import List, Dict, Optional
 class TemplateScript:
     def __init__(self, path: str = None, url: str = None, is_async: bool = False):
         if path and url:
-            raise AttributeError("a script can only have one source from either a path or url.")
+            raise AttributeError(
+                "a script can only have one source from either a path or url."
+            )
         elif not (path or url):
-            raise AttributeError("must give either a local path or a url for TemplateScript.")
+            raise AttributeError(
+                "must give either a local path or a url for TemplateScript."
+            )
         self.path = path
         self.is_async = is_async
         self.url = url

--- a/polaris/polaris/management/commands/testnet.py
+++ b/polaris/polaris/management/commands/testnet.py
@@ -69,6 +69,7 @@ class Command(BaseCommand):
         state after a testnet reset. Currently this involves the following:
 
         - re-issuing every Asset object in the DB
+        - moves all `pending_trust` Transactions to `error`
         - setting the most-recently streamed Transaction object's
             `paging_token` attribute to None. This signals to
             watch_transactions to stream using the `"now"` keyword.

--- a/polaris/polaris/management/commands/testnet.py
+++ b/polaris/polaris/management/commands/testnet.py
@@ -66,7 +66,6 @@ class Command(BaseCommand):
             `paging_token` attribute to None. This signals to
             watch_transactions to stream using the `"now"` keyword.
         """
-        pass
 
     def issue(self, **options):
         """
@@ -140,7 +139,7 @@ class Command(BaseCommand):
             limit = amount if src == issuer else None
             tb.append_change_trust_op(code, issuer.public_key, limit, dest.public_key)
             payment_amount = amount
-        elif balance < amount:
+        elif Decimal(balance) < amount:
             print(f"\nReplenishing {code} balance to {amount} for {dest.public_key}")
             payment_amount = amount - Decimal(balance)
 

--- a/polaris/polaris/management/commands/testnet.py
+++ b/polaris/polaris/management/commands/testnet.py
@@ -1,0 +1,182 @@
+import urllib3
+from decimal import Decimal
+from typing import Optional
+from logging import getLogger
+
+from django.core.management.base import BaseCommand
+from stellar_sdk import Keypair, TransactionBuilder, Server
+from stellar_sdk.account import Account, Thresholds
+from stellar_sdk.exceptions import NotFoundError, ConnectionError, BaseHorizonError
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.reset_parser = None
+        self.issue_parser = None
+        self.server = Server("https://horizon-testnet.stellar.org")
+        self.http = urllib3.PoolManager()
+
+    def add_arguments(self, parser):
+        subparsers = parser.add_subparsers(dest="subcommands", required=True)
+        self.reset_parser = subparsers.add_parser(
+            "reset", help="a sub-command for testnet resets"
+        )
+        self.issue_parser = subparsers.add_parser(
+            "issue", help="a sub-command for issuing assets on testnet"
+        )
+        self.issue_parser.add_argument(
+            "--asset", "-a", help="the code of the asset issued"
+        )
+        self.issue_parser.add_argument(
+            "--issuer-seed", "-i", help="the issuer's secret key"
+        )
+        self.issue_parser.add_argument(
+            "--distribution-seed", "-d", help="the distribution account's secret key"
+        )
+        self.issue_parser.add_argument(
+            "--client-seed", "-c", help="the client account's secret key"
+        )
+        self.issue_parser.add_argument(
+            "--issue-amount",
+            type=Decimal,
+            help="the amount sent to distribution account. Also the limit for the trustline.",
+        )
+        self.issue_parser.add_argument(
+            "--client-amount",
+            type=Decimal,
+            help="the amount sent to client account. Also the limit for the trustline.",
+        )
+
+    def handle(self, *args, **options):
+        if options.get("subcommands") == "reset":
+            self.reset(**options)
+        elif options.get("subcommands") == "issue":
+            self.issue(**options)
+
+    def reset(self, **options):
+        """
+        Perform any necessary functions to ensure the anchor is in a valid
+        state after a testnet reset. Currently this involves the following:
+
+        - re-issuing every Asset object in the DB
+        - setting the most-recently streamed Transaction object's
+            `paging_token` attribute to None. This signals to
+            watch_transactions to stream using the `"now"` keyword.
+        """
+        pass
+
+    def issue(self, **options):
+        """
+        Issue the asset specified using the `options` passed to the subcommand
+        or function call. The code here is a port of the following project:
+
+        https://github.com/stellar/create-stellar-token
+
+        Users can setup distribution and client accounts for the asset being
+        issued as well.
+        """
+        code = options.get("asset") or "TEST"
+        issuer = Keypair.from_secret(
+            options.get("issuer_seed") or Keypair.random().secret
+        )
+        distributor = Keypair.from_secret(
+            options.get("distribution_seed") or Keypair.random().secret
+        )
+        client, client_amount = None, None
+        if options.get("client_seed") or options.get("client_amount"):
+            client = Keypair.from_secret(
+                options.get("client_seed") or Keypair.random().secret
+            )
+            client_amount = options.get("client_amount") or Decimal(1000)
+        issue_amount = options.get("issue_amount") or Decimal(100000)
+
+        print("\nIssuer account public and private keys:")
+        print(f"public key: {issuer.public_key}")
+        print(f"secret key: {issuer.secret}\n")
+        print("Distribution account public and private keys:")
+        print(f"public key: {distributor.public_key}")
+        print(f"secret key: {distributor.secret}\n")
+        print(f"Issuing {issue_amount} {code} to the distribution account")
+        if client:
+            print("\nClient account public and private keys:")
+            print(f"public key: {client.public_key}")
+            print(f"secret key: {client.secret}\n")
+            print(f"Sending {client_amount} to the client account\n")
+
+        accounts = {}
+        for kp in [issuer, distributor, client]:
+            if not kp:
+                continue
+            try:
+                accounts[kp.public_key] = (
+                    self.server.accounts().account_id(kp.public_key).call()
+                )
+            except NotFoundError:
+                print(f"Funding {kp.public_key} ...")
+                self.http.request(
+                    "GET", f"https://friendbot.stellar.org?addr={kp.public_key}"
+                )
+                accounts[kp.public_key] = (
+                    self.server.accounts().account_id(kp.public_key).call()
+                )
+
+        self.add_balance(code, issue_amount, accounts, distributor, issuer, issuer)
+        if client:
+            self.add_balance(code, client_amount, accounts, client, distributor, issuer)
+
+    def add_balance(self, code, amount, accounts, dest, src, issuer):
+        tb = TransactionBuilder(
+            self.account_from_json(accounts[src.public_key]),
+            base_fee=500,
+            network_passphrase="Test SDF Network ; September 2015",
+        )
+        payment_amount = None
+        balance = self.get_balance(code, accounts[dest.public_key])
+        if not balance:
+            print(f"\nCreating {code} trustline for {dest.public_key}")
+            limit = amount if src == issuer else None
+            tb.append_change_trust_op(code, issuer.public_key, limit, dest.public_key)
+            payment_amount = amount
+        elif balance < amount:
+            print(f"\nReplenishing {code} balance to {amount} for {dest.public_key}")
+            payment_amount = amount - Decimal(balance)
+
+        print(f"Sending {code} payment of {payment_amount} to {dest.public_key}")
+        tb.append_payment_op(
+            dest.public_key, payment_amount, code, issuer.public_key, src.public_key
+        )
+        envelope = tb.set_timeout(30).build()
+        envelope.sign(src)
+        if len(tb.operations) == 2:
+            # We only need the destination's signature if we're adding a trustline
+            # to the account
+            envelope.sign(dest)
+        try:
+            self.server.submit_transaction(envelope)
+        except BaseHorizonError as e:
+            print(
+                f"Failed to send {code} payment to {dest.public_key}. "
+                f"Result codes: {e.extras.get('result_codes')}"
+            )
+        else:
+            print("Success!")
+
+    def account_from_json(self, json):
+        sequence = int(json["sequence"])
+        thresholds = Thresholds(
+            json["thresholds"]["low_threshold"],
+            json["thresholds"]["med_threshold"],
+            json["thresholds"]["high_threshold"],
+        )
+        account = Account(account_id=json["id"], sequence=sequence)
+        account.signers = json["signers"]
+        account.thresholds = thresholds
+        return account
+
+    def get_balance(self, code, json) -> Optional[str]:
+        for balance_obj in json["balances"]:
+            if balance_obj.get("asset_code") == code:
+                return balance_obj["balance"]


### PR DESCRIPTION
resolves stellar/django-polaris#266

Adds a Django command so anchors can issue assets mirroring the https://github.com/stellar/create-stellar-token project.

Also adds a `reset` subcommand for reseting the most-recent `paging_token` for each anchored asset and re-issues each asset in the DB. `paging_token` must be reset when testnet resets so Polaris can begin streaming from the network again.

Also includes formatting changes from @acharb 's recent commit on script integrations. Polaris uses the [black](https://pypi.org/project/black/) formatter for its python code.

TODO: update `pending_trust` transactions to `error`