### PR TITLE
Added docs on CLI commands

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -17,6 +17,7 @@ django-polaris documentation contents
     forms/index
     middleware/index
     internationalization/index
+    CLI commands <deployment/index>
 
 
 Indices and tables

--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -52,7 +52,7 @@ The ``testnet`` command comes with two subcommands, ``issue`` and ``reset``.
 
 ``issue`` allows users to create assets on the Stellar testnet network, porting the functionality originally offered by the `create-stellar-token`_ tool. When the test network resets, you'll have to reissue your assets.
 
-``reset`` calls the functionality involved with ``issue`` for each asset in the anchor's database. Since the database does not store the issuing account's secret key, the user must input each key as requested by the Polaris command. It also performs a couple other functions necessary to ensure your Polaris instance runs successfully after a testnet reset:
+``reset`` calls the functionality invoked with ``issue`` for each asset in the anchor's database. Since the database does not store the issuing account's secret key, the user must input each key as requested by the Polaris command. It also performs a couple other functions necessary to ensure your Polaris instance runs successfully after a testnet reset:
 
 - Moves all ``pending_trust`` transactions to ``error``
 

--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -1,0 +1,63 @@
+============
+CLI Commands
+============
+
+Deploying Polaris
+-----------------
+
+Implementing SEP 6, 24, or 31 requires more than a web server. Anchors must also stream incoming transactions to their asset's distribution accounts, check for incoming deposits to their off-chain accounts, confirm off-chain transfers, and more.
+
+To support these requirements, Polaris deployments must also include additional services to run alongside the web server. The SDF currently deploys Polaris using its CLI commands. Each command either periodically checks external state or constantly streams events from an external data source.
+
+With the exception of `watch_transactions`, every CLI command can be run once or repeatedly on some interval using the `--loop` and `--interval <seconds>` arguments. These commands should either be run by a job scheduler like Jenkins and CircleCI or run with the `--loop` argument.
+
+watch_transactions
+^^^^^^^^^^^^^^^^^^
+
+This process streams transactions to and from each anchored asset's distribution account. Outgoing transactions are filtered out, and incoming transactions are matched with pending SEP 6, 24, or 31 transactions in the database using the `memo` field. Matched transactions have their statuses updated to ``pending_receiver`` for SEP-31 and ``pending_anchor`` for SEP-6 and 24.
+
+execute_outgoing_transactions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This process periodically queries for transactions that are ready to be executed off-chain and calls Polaris' ``RailsIntegration.execute_outgoing_transaction`` integration function for each one. "Ready" transactions are those in ``pending_receiver`` or ``pending_anchor`` statuses, among other conditions. Anchor are expected to update the ``Transaction.status`` to ``completed`` or ``pending_external`` if initiating the transfer was successful.
+
+poll_outgoing_transactions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Polaris periodically queries for transactions in ``pending_external`` and passes them to the ``RailsIntegration.poll_outgoing_transactions``. The anchor is expected to update the transactions' status depending on if the transfer has been successful or not.
+
+poll_pending_deposits
+^^^^^^^^^^^^^^^^^^^^^
+
+Polaris periodically queries for transactions in ``pending_user_transfer_start`` and ``pending_sender`` and passes them to the ``RailsIntegration.poll_pending_deposits`` integration function. The anchor is expected to update the transactions' status depending on the if the funds have become available in the anchor's off-chain account.
+
+check_trustlines
+^^^^^^^^^^^^^^^^
+
+And finally, Polaris periodically checks for transactions whose accounts don't have trustlines for the asset the account is requesting using the ``pending_trust`` status. Polaris will update ``Transaction.status`` for each transaction that has a trustline to the relevant asset.
+
+If you choose to deploy Polaris using this strategy, ensure the processes are managed and kept persistent using a process-control system like ``supervisorctl``.
+
+Testnet Resets
+--------------
+
+If you're running your anchor service on testnet, you'll need to reset Polaris' state every time the network resets. Polaris comes with a command that automates this process.
+
+testnet
+^^^^^^^
+
+.. _create-stellar-token: https://github.com/stellar/create-stellar-token
+
+The ``testnet`` command comes with two subcommands, ``issue`` and ``reset``.
+
+``issue`` allows users to create assets on the Stellar testnet network, porting the functionality originally offered by the `create-stellar-token`_ tool. When the test network resets, you'll have to reissue your assets.
+
+``reset`` calls the functionality involved with ``issue`` for each asset in the anchor's database. Since the database does not store the issuing account's secret key, the user must input each key as requested by the Polaris command. It also performs a couple other functions necessary to ensure your Polaris instance runs successfully after a testnet reset:
+
+- Moves all ``pending_trust`` transactions to ``error``
+
+This is done because all accounts have been cleared from the network. While its possible an account that required a trustline could be recreated and a trustline could be established, its unlikely. Polaris assumes a testnet reset makes in-progress transactions unrecoverable.
+
+- Updates the ``paging_token` of latest transaction streamed for each anchored asset
+
+``watch_transactions`` streams transactions to and from each anchored asset's distribution account. Specifically, it streams transactions starting with the most recently completed transaction's ``paging_token`` on startup. When the testnet resets, the ``paging_token`` used for transactions prior to the reset are no longer valid. To fix this, Polaris updates the ``paging_token`` of the most recently completed transaction for each anchored asset to ``"now"``.

--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -58,6 +58,6 @@ The ``testnet`` command comes with two subcommands, ``issue`` and ``reset``.
 
 This is done because all accounts have been cleared from the network. While its possible an account that required a trustline could be recreated and a trustline could be established, its unlikely. Polaris assumes a testnet reset makes in-progress transactions unrecoverable.
 
-- Updates the ``paging_token` of latest transaction streamed for each anchored asset
+- Updates the ``paging_token`` of latest transaction streamed for each anchored asset
 
 ``watch_transactions`` streams transactions to and from each anchored asset's distribution account. Specifically, it streams transactions starting with the most recently completed transaction's ``paging_token`` on startup. When the testnet resets, the ``paging_token`` used for transactions prior to the reset are no longer valid. To fix this, Polaris updates the ``paging_token`` of the most recently completed transaction for each anchored asset to ``"now"``.

--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -9,7 +9,7 @@ Implementing SEP 6, 24, or 31 requires more than a web server. Anchors must also
 
 To support these requirements, Polaris deployments must also include additional services to run alongside the web server. The SDF currently deploys Polaris using its CLI commands. Each command either periodically checks external state or constantly streams events from an external data source.
 
-With the exception of `watch_transactions`, every CLI command can be run once or repeatedly on some interval using the `--loop` and `--interval <seconds>` arguments. These commands should either be run by a job scheduler like Jenkins and CircleCI or run with the `--loop` argument.
+With the exception of ``watch_transactions``, every CLI command can be run once or repeatedly on some interval using the ``--loop`` and ``--interval <seconds>`` arguments. These commands should either be run by a job scheduler like Jenkins and CircleCI or run with the ``--loop`` argument.
 
 watch_transactions
 ^^^^^^^^^^^^^^^^^^

--- a/docs/sep31/index.rst
+++ b/docs/sep31/index.rst
@@ -54,7 +54,7 @@ Running the Service
 ===================
 
 In addition to the web server, SEP-31 requires three additional processes to be run
-in order to work.
+in order to work. See the :doc:`<CLI Commands /deployment/index>` for more information on all Polaris commands.
 
 Watch Transactions
 ^^^^^^^^^^^^^^^^^^

--- a/docs/sep31/index.rst
+++ b/docs/sep31/index.rst
@@ -54,7 +54,7 @@ Running the Service
 ===================
 
 In addition to the web server, SEP-31 requires three additional processes to be run
-in order to work. See the :doc:`<CLI Commands /deployment/index>` for more information on all Polaris commands.
+in order to work. See the :doc:`CLI Commands </deployment/index>` for more information on all Polaris commands.
 
 Watch Transactions
 ^^^^^^^^^^^^^^^^^^

--- a/docs/sep6_and_sep24/index.rst
+++ b/docs/sep6_and_sep24/index.rst
@@ -253,8 +253,7 @@ Javascript Integration
 Running the Service
 ===================
 
-In addition to the web server, SEP-6 and SEP-24 require five additional processes
-to be run in order to work.
+In addition to the web server, SEP-6 and SEP-24 require five additional processes to be run in order to work. See the :doc:`<CLI Commands /deployment/index>` for more information on all Polaris commands.
 
 Polling Pending Deposits
 ------------------------

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -107,27 +107,21 @@ Within the ``BASE_DIR`` directory, write the following variables to a ``.env`` f
     HOST_URL="http://localhost:8000"
     LOCAL_MODE=1
     SERVER_JWT_KEY="supersecretjwtencodingstring"
+    SIGNING_SEED=
 
-Many of these are self-explanatory, but ``LOCAL_MODE`` ensures Polaris runs properly using HTTP. In production Polaris should run under HTTPS. ``SERVER_JWT_KEY`` is a secret string used to encode the client's authenticated session as a token.
+Many of these are self-explanatory, but ``LOCAL_MODE`` ensures Polaris runs properly using HTTP. In production Polaris should run under HTTPS. ``SERVER_JWT_KEY`` is a secret string used to encode the client's authenticated session as a token. Finally, ``SIGNING_SEED`` should be the secret key for the keypair you intend to use for signing SEP-10 challenge transactions.
 
 There is one more variable that must be added to ``.env``, but we're going to wait until we issue the asset we intend to anchor.
 
 Issue and add your asset
 ------------------------
 
-.. _`this tool`: https://github.com/stellar/create-stellar-token
-
-Use `this tool`_ to create a token as well as setup issuer and distribution accounts for a fake asset we're going to anchor.
+Use Polaris' ``testnet issue`` subcommand to create a token as well as setup issuer and distribution accounts for a fake asset we're going to anchor.
 ::
 
-    npx create-stellar-token --asset=TEST
+    python app/manage.py testnet issue --asset=TEST
 
 It should output a public and secret key for both the issuer and distribution account.
-
-Now, add an environment variable for the account used to sign SEP-10 transactions. You can use a random keypair, but a common pattern is to use the distribution account's public key. In ``.env`` or ``ENV_PATH``:
-::
-
-    SIGNING_SEED=<TEST's distribution account seed>
 
 Add the asset to the database
 -----------------------------


### PR DESCRIPTION
Initially taken from stellar/django-polaris#274

The docs could use descriptions of each of the CLI commands.