### PR TITLE
Use settings.py if variable is not found in environment

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,7 +135,7 @@ Polaris also supports specifying your environment variables in your project's ``
     POLARIS_HORIZON_URI = "https://horizon-testnet.stellar.org/"
     POLARIS_HOST_URL = "https://example.com"
 
-If a variable cannot be found in the environment, Polaris will look in the ``settings.py`` file. Be careful not to check in secrets like your ``SERVER_JWT_KEY`` into your version control history, especially if your repository is not private.
+If a variable cannot be found in the environment, Polaris will look in the ``settings.py`` file, or more generally, ``django.conf.settings``. Be careful not to check in secrets like your ``SERVER_JWT_KEY`` into your version control history, especially if your repository is not private.
 
 Endpoints
 ^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,13 +121,21 @@ You may want to configure the ``LEVEL`` of the Polaris logger differently depend
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
-Polaris uses environment variables that should be defined in the
-environment or included in ``BASE_DIR/.env`` or ``POLARIS_ENV_PATH``.
+Polaris uses environment variables that should be defined in the environment or included in ``BASE_DIR/.env`` or ``POLARIS_ENV_PATH``.
 ::
 
     STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
     HORIZON_URI="https://horizon-testnet.stellar.org/"
     HOST_URL="https://example.com"
+
+Polaris also supports specifying your environment variables in your project's ``settings.py``. However, any variable Polaris expects in the environment must be prepended with ``POLARIS_`` if declared in `settings.py``. For example,
+::
+
+    POLARIS_STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+    POLARIS_HORIZON_URI="https://horizon-testnet.stellar.org/"
+    POLARIS_HOST_URL="https://example.com"
+
+If a variable cannot be found in the environment, Polaris will look in the ``settings.py`` file. Be careful not to check in secrets like your ``SERVER_JWT_KEY`` into your version control history, especially if your repository is not private.
 
 Endpoints
 ^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -131,9 +131,9 @@ Polaris uses environment variables that should be defined in the environment or 
 Polaris also supports specifying your environment variables in your project's ``settings.py``. However, any variable Polaris expects in the environment must be prepended with ``POLARIS_`` if declared in `settings.py``. For example,
 ::
 
-    POLARIS_STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
-    POLARIS_HORIZON_URI="https://horizon-testnet.stellar.org/"
-    POLARIS_HOST_URL="https://example.com"
+    POLARIS_STELLAR_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+    POLARIS_HORIZON_URI = "https://horizon-testnet.stellar.org/"
+    POLARIS_HOST_URL = "https://example.com"
 
 If a variable cannot be found in the environment, Polaris will look in the ``settings.py`` file. Be careful not to check in secrets like your ``SERVER_JWT_KEY`` into your version control history, especially if your repository is not private.
 

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -51,7 +51,6 @@ HOST_URL = env_or_settings("HOST_URL")
 LOCAL_MODE = env_or_settings("LOCAL_MODE", bool=True) or False
 
 # Constants
-
 OPERATION_DEPOSIT = "deposit"
 OPERATION_WITHDRAWAL = "withdraw"
 ACCOUNT_STARTING_BALANCE = str(2.01)

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -5,36 +5,50 @@ Polaris-specific settings. This is not django.conf.settings.
 import os
 import environ
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from stellar_sdk.server import Server
 from stellar_sdk.keypair import Keypair
+
+
+def env_or_settings(variable, bool=False):
+    try:
+        return env.bool(variable) if bool else env(variable)
+    except ImproperlyConfigured as e:
+        if hasattr(settings, "POLARIS_" + variable):
+            return getattr(settings, "POLARIS_" + variable)
+        else:
+            return None
 
 
 env = environ.Env()
 env_file = os.path.join(getattr(settings, "BASE_DIR", ""), ".env")
 if os.path.exists(env_file):
     env.read_env(env_file)
-elif hasattr(settings, "POLARIS_ENV_PATH") and os.path.exists(
-    settings.POLARIS_ENV_PATH
-):
-    env.read_env(settings.POLARIS_ENV_PATH)
+elif hasattr(settings, "POLARIS_ENV_PATH"):
+    if os.path.exists(settings.POLARIS_ENV_PATH):
+        env.read_env(settings.POLARIS_ENV_PATH)
+    else:
+        raise ImproperlyConfigured(
+            f"Could not find env file at {settings.POLARIS_ENV_PATH}"
+        )
 
 SIGNING_SEED, SIGNING_KEY = None, None
 if "sep-10" in settings.POLARIS_ACTIVE_SEPS:
-    SIGNING_SEED = env("SIGNING_SEED")
+    SIGNING_SEED = env_or_settings("SIGNING_SEED")
     SIGNING_KEY = Keypair.from_secret(SIGNING_SEED).public_key
 
 SERVER_JWT_KEY = None
 if any(sep in settings.POLARIS_ACTIVE_SEPS for sep in ["sep-10", "sep-24"]):
-    SERVER_JWT_KEY = env("SERVER_JWT_KEY")
+    SERVER_JWT_KEY = env_or_settings("SERVER_JWT_KEY")
 
-STELLAR_NETWORK_PASSPHRASE = env(
-    "STELLAR_NETWORK_PASSPHRASE", default="Test SDF Network ; September 2015"
+STELLAR_NETWORK_PASSPHRASE = (
+    env_or_settings("STELLAR_NETWORK_PASSPHRASE") or "Test SDF Network ; September 2015"
 )
-HORIZON_URI = env("HORIZON_URI", default="https://horizon-testnet.stellar.org/")
+HORIZON_URI = env_or_settings("HORIZON_URI") or "https://horizon-testnet.stellar.org/"
 HORIZON_SERVER = Server(horizon_url=HORIZON_URI)
-HOST_URL = env("HOST_URL")
+HOST_URL = env_or_settings("HOST_URL")
 
-LOCAL_MODE = env.bool("LOCAL_MODE", default=False)
+LOCAL_MODE = env_or_settings("LOCAL_MODE", bool=True) or False
 
 # Constants
 


### PR DESCRIPTION
resolves stellar/django-polaris#248

Looks in `django.conf.settings` (settings.py) if no variable with the given name is found in the environment. This allows Polaris users to put all settings in settings.py.