### PR TITLE
Remove Polaris middleware requirement

### DIFF
--- a/docs/internationalization/index.rst
+++ b/docs/internationalization/index.rst
@@ -35,7 +35,6 @@ You must also add ``django.middleware.locale.LocaleMiddleware`` to your
 
     MIDDLEWARE = [
         ...,
-        'polaris.middleware.PolarisSameSiteMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.locale.LocaleMiddleware',
         'corsheaders.middleware.CorsMiddleware',

--- a/docs/sep6_and_sep24/index.rst
+++ b/docs/sep6_and_sep24/index.rst
@@ -100,9 +100,10 @@ so add the follow environment variable.
 
     SERVER_JWT_KEY="yoursupersecretjwtkey"
 
-Add Polaris' ``PolarisSameSiteMiddleware`` to your
-``settings.MIDDLEWARE``. ``SessionMiddleware`` must be listed `below`
-``PolarisSameSiteMiddleware``.
+Some wallets may open the interactive URL's returned by Polaris in iframes instead of popups.
+This affects the way in which HTTPS cookie headers must be configured. Add Polaris' ``PolarisSameSiteMiddleware`` to your ``settings.MIDDLEWARE`` if you want to support wallets using iframes.
+
+``SessionMiddleware`` is required for all SEP-24 deployments, and must be listed `below` ``PolarisSameSiteMiddleware``.
 ::
 
     MIDDLEWARE = [

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -36,18 +36,18 @@ Add the following to ``INSTALLED_APPS`` in settings.py.
         "polaris",
     ]
 
-Add the following to your ``MIDDLEWARE`` list. Make sure ``PolarisSameSiteMiddleware`` is
-above ``SessionMiddleware`` and ``WhiteNoiseMiddleware`` is below ``CorsMiddleware``.
+Add the following to your ``MIDDLEWARE`` list. Make sure ``WhiteNoiseMiddleware`` is below ``CorsMiddleware``.
 ::
 
     MIDDLEWARE = [
         ...,
         'corsheaders.middleware.CorsMiddleware',
         'whitenoise.middleware.WhiteNoiseMiddleware',
-        'polaris.middleware.PolarisSameSiteMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         ...
     ]
+
+:doc:`PolarisSameSiteMiddleware </middleware/index>` can also be used if your anchor service should support wallets that use iframes to open interactive URL's. Popups are the recommend strategy per SEP-24.
 
 Ensure ``BASE_DIR`` is defined. Django adds this setting automatically, and Polaris expects a ``.env`` file to be present in this directory. If this setting isn't present, or if the ``.env`` isn't found there, Polaris will try to use the ``ENV_PATH`` setting. You can also use the `environ` package installed with Polaris to configure your settings.py variables with values stored in your environment.
 ::

--- a/example/server/settings.py
+++ b/example/server/settings.py
@@ -45,7 +45,6 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
-    "polaris.middleware.PolarisSameSiteMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.locale.LocaleMiddleware",

--- a/polaris/polaris/middleware.py
+++ b/polaris/polaris/middleware.py
@@ -3,12 +3,12 @@ class PolarisSameSiteMiddleware:
     Middleware to add a `SameSite=None` attribute to the session cookie for
     `deposit/webapp` responses. This is a work-around in-place of
     :class:`django.http.HttpResponse.set_cookie`, which does not
-    allow `samesite` values of ``None``.
+    allow `samesite` values of ``None``. **This is only required if you want
+    to support clients that open interactive URLs in iframes instead of
+    the recommended strategy of using popups.
 
-    Polaris developers MUST add this class to their Django app's
-    ``settings.MIDDLEWARE``. Specifically, the class must be listed
-    `above` :class:`django.contrib.sessions.middleware.SessionMiddleware`,
-    like so:
+    If used, the class must be listed `above`
+    :class:`django.contrib.sessions.middleware.SessionMiddleware`, like so:
     ::
 
         MIDDLEWARE = [

--- a/polaris/polaris/sep24/utils.py
+++ b/polaris/polaris/sep24/utils.py
@@ -235,20 +235,12 @@ def check_sep24_config():
 def check_middleware():
     """
     Ensures the Django app running Polaris has the correct middleware
-    configuration. Polaris requires SessionMiddleware and
-    PolarisSameSiteMiddleware to be installed.
+    configuration. Polaris requires SessionMiddleware to be installed.
     """
     err_msg = "{} is not installed in settings.MIDDLEWARE"
     session_middleware_path = "django.contrib.sessions.middleware.SessionMiddleware"
-    if import_path not in django_settings.MIDDLEWARE:
-        raise ValueError(err_msg.format(import_path))
-    elif session_middleware_path not in django_settings.MIDDLEWARE:
+    if session_middleware_path not in django_settings.MIDDLEWARE:
         raise ValueError(err_msg.format(session_middleware_path))
-    elif django_settings.MIDDLEWARE.index(
-        import_path
-    ) > django_settings.MIDDLEWARE.index(session_middleware_path):
-        err_msg = f"{import_path} must be listed before {session_middleware_path}"
-        raise ValueError(err_msg)
 
 
 def check_protocol():


### PR DESCRIPTION
resolves stellar/django-polaris#294

`PolarisSameSiteMiddleware` was introduced when iframes were the recommended way to open interactive URLs. However, this recommendation has been changed to popups. 

This changes the HTTPS cookie policy required to persist session cookies. Specifically it makes it such that the `SameSite` flag doesn't need to be `None`, which is what `PolarisSameSiteMiddleware` did.