### PR TITLE
Change SEP-12 DELETE exception from ValueError to ObjectDoesNotExist

### DIFF
--- a/polaris/polaris/integrations/customers.py
+++ b/polaris/polaris/integrations/customers.py
@@ -63,8 +63,8 @@ class CustomerIntegration:
     def delete(self, account: str, memo: Optional[str], memo_type: Optional[str]):
         """
         Delete the record of the customer specified by `account`, `memo`, and `memo_type`.
-        If such a record does not exist, raise a ``ValueError`` for Polaris to return a
-        404 Not Found response.
+        If such a record does not exist, raise a ``ObjectDoesNotExist`` exception for Polaris
+        to return a 404 Not Found response.
 
         :param account: the stellar account associated with the customer
         :param memo: the optional memo used to create the customer

--- a/polaris/polaris/sep12/customer.py
+++ b/polaris/polaris/sep12/customer.py
@@ -127,7 +127,7 @@ def delete(account_from_auth: str, request: Request, account: str) -> Response:
         return render_error_response("invalid 'memo' for 'memo_type'")
     try:
         rci.delete(account, memo, request.data.get("memo_type"))
-    except ValueError:
+    except ObjectDoesNotExist:
         return render_error_response("account not found", status_code=404)
     else:
         return Response({}, status=200)

--- a/polaris/polaris/tests/sep12/test_customer.py
+++ b/polaris/polaris/tests/sep12/test_customer.py
@@ -443,7 +443,7 @@ def test_delete_memo_customer(mock_delete, client):
     mock_delete.assert_called_with("test source address", "a valid text memo", "text")
 
 
-mock_bad_delete = Mock(side_effect=ValueError)
+mock_bad_delete = Mock(side_effect=ObjectDoesNotExist)
 
 
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)


### PR DESCRIPTION
resolves stellar/django-polaris#306

Simple but breaking change. Updates the exception to match the other functions for SEP-12.