### PR TITLE
exit commands gracefully

### DIFF
--- a/polaris/polaris/management/commands/check_trustlines.py
+++ b/polaris/polaris/management/commands/check_trustlines.py
@@ -18,6 +18,7 @@ class Command(BaseCommand):
     Create Stellar transaction for deposit transactions marked as pending trust, if a
     trustline has been created.
     """
+
     default_interval = 60
     _terminate = False
 

--- a/polaris/polaris/management/commands/check_trustlines.py
+++ b/polaris/polaris/management/commands/check_trustlines.py
@@ -29,6 +29,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def exit_gracefully(sig, frame):
+        logger.info("Exiting check_trustlines...")
         module = sys.modules[__name__]
         module.TERMINATE = True
 

--- a/polaris/polaris/management/commands/execute_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/execute_outgoing_transactions.py
@@ -27,6 +27,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def exit_gracefully(sig, frame):
+        logger.info("Exiting execute_outgoing_transactions...")
         module = sys.modules[__name__]
         module.TERMINATE = True
 

--- a/polaris/polaris/management/commands/poll_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/poll_outgoing_transactions.py
@@ -21,7 +21,9 @@ class Command(BaseCommand):
         signal.signal(signal.SIGINT, self.exit_gracefully)
         signal.signal(signal.SIGTERM, self.exit_gracefully)
 
-    def exit_gracefully(self, sig, frame):
+    @staticmethod
+    def exit_gracefully(sig, frame):
+        logger.info("Exiting poll_outgoing_transactions...")
         module = sys.modules[__name__]
         module.TERMINATE = True
 

--- a/polaris/polaris/management/commands/poll_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/poll_outgoing_transactions.py
@@ -14,7 +14,7 @@ logger = getLogger(__name__)
 
 class Command(BaseCommand):
     default_interval = 30
-    terminate = False
+    _terminate = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -22,11 +22,14 @@ class Command(BaseCommand):
         signal.signal(signal.SIGTERM, self.exit_gracefully)
 
     def exit_gracefully(self, sig, frame):
-        self.terminate = True
+        self._terminate = True
+
+    def terminate(self):
+        return self._terminate
 
     def sleep(self, seconds):
         for i in range(0, seconds):
-            if self.terminate:
+            if self.terminate():
                 break
             time.sleep(1)
 
@@ -49,7 +52,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options.get("loop"):
             while True:
-                if self.terminate:
+                if self.terminate():
                     break
                 self.poll_outgoing_transactions()
                 self.sleep(options.get("interval") or self.default_interval)

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -70,7 +70,8 @@ class Command(BaseCommand):
         signal.signal(signal.SIGTERM, self.exit_gracefully)
 
     @staticmethod
-    def exit_gracefully(self, sig, frame):
+    def exit_gracefully(sig, frame):
+        logger.info("Exiting poll_pending_deposits...")
         module = sys.modules[__name__]
         module.TERMINATE = True
 

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -113,10 +113,6 @@ class Command(BaseCommand):
         Right now, execute_deposits assumes all pending deposits are SEP-6 or 24
         transactions. This may change in the future if Polaris adds support for
         another SEP that checks for incoming deposits.
-
-        :param terminate_func: optional function that returns True or False:
-            - if True, this function will exit gracefully
-            - if False, this function will keep running until it finishes
         """
         module = sys.modules[__name__]
         pending_deposits = Transaction.objects.filter(


### PR DESCRIPTION
The management commands need to gracefully exit, otherwise they can be interrupted in the middle of transactions and the database might get inconsistent.
This pull request uses the native `signal` module to register the `SIGINT` and `SIGTERM` signals. When the process is either interrupted by Ctrl+C or killed, it finishes the current loop iteration and then exits.

Without a graceful exit, a common scenario that can cause issues is when the code is being deployed/updated on the server, and all the management commands get killed in order to be restarted to run the new code. This can cause the process to stop at a random point and some transactions might get into an inconsistent state in the database (went through but status wasn't updated, etc).