### PR TITLE
Disallow including the token after previously being authenticated

### DIFF
--- a/polaris/polaris/sep24/utils.py
+++ b/polaris/polaris/sep24/utils.py
@@ -13,11 +13,8 @@ from django.utils.translation import gettext as _
 from django.conf import settings as django_settings
 from django.urls import reverse
 
-from django.contrib.sessions.backends.base import SessionBase
-
 from polaris import settings
 from polaris.utils import getLogger
-from polaris.middleware import import_path
 from polaris.models import Asset, Transaction
 from polaris.utils import render_error_response, verify_valid_asset_operation
 

--- a/polaris/polaris/sep24/utils.py
+++ b/polaris/polaris/sep24/utils.py
@@ -13,6 +13,8 @@ from django.utils.translation import gettext as _
 from django.conf import settings as django_settings
 from django.urls import reverse
 
+from django.contrib.sessions.backends.base import SessionBase
+
 from polaris import settings
 from polaris.utils import getLogger
 from polaris.middleware import import_path
@@ -91,12 +93,14 @@ def authenticate_session_helper(r: Request):
                 id=tid, stellar_account=r.session["account"]
             )
             if not (tid in r.session.get("transactions", []) and tqs.exists()):
-                raise ValueError(f"Not authenticated for transaction ID: {tid}")
+                raise ValueError(f"not authenticated for transaction ID: {tid}")
             else:  # pragma: no cover
                 # client has been authenticated for the requested transaction
                 return
         else:
-            raise ValueError("Missing authentication token")
+            raise ValueError("missing authentication token")
+    elif r.session.exists():
+        raise ValueError("unexpected one-time auth token")
 
     try:
         jwt_dict = jwt.decode(token, settings.SERVER_JWT_KEY, algorithms=["HS256"])
@@ -105,15 +109,15 @@ def authenticate_session_helper(r: Request):
 
     now = time.time()
     if jwt_dict["iss"] != r.build_absolute_uri("interactive"):
-        raise ValueError(_("Invalid token issuer"))
+        raise ValueError(_("invalid token issuer"))
     elif jwt_dict["iat"] > now or jwt_dict["exp"] < now:
-        raise ValueError(_("Token is not yet valid or is expired"))
+        raise ValueError(_("token is not yet valid or is expired"))
 
     transaction_qs = Transaction.objects.filter(
         id=jwt_dict["jti"], stellar_account=jwt_dict["sub"]
     )
     if not transaction_qs.exists():
-        raise ValueError(_("Transaction for account not found"))
+        raise ValueError(_("transaction for account not found"))
 
     # JWT is valid, authenticate session
     r.session["authenticated"] = True

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -182,7 +182,7 @@ def test_interactive_deposit_no_token(client):
     response.
     """
     response = client.get(WEBAPP_PATH)
-    assert "Missing authentication token" in str(response.content)
+    assert "Missing authentication token" in response.content.decode()
     assert response.status_code == 403
 
 

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -253,6 +253,16 @@ def test_interactive_deposit_success(client, acc1_usd_deposit_transaction_factor
     assert response.status_code == 200
     assert client.session["authenticated"] is True
 
+    response = client.get(
+        f"{WEBAPP_PATH}"
+        f"?token={token}"
+        f"&transaction_id={deposit.id}"
+        f"&asset_code={deposit.asset.code}"
+    )
+    assert response.status_code == 403
+
+    assert "Unexpected one-time auth token" in str(response.content)
+
     response = client.post(
         f"{WEBAPP_PATH}/submit"
         f"?transaction_id={deposit.id}"

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -260,7 +260,6 @@ def test_interactive_deposit_success(client, acc1_usd_deposit_transaction_factor
         f"&asset_code={deposit.asset.code}"
     )
     assert response.status_code == 403
-
     assert "Unexpected one-time auth token" in str(response.content)
 
     response = client.post(

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -182,7 +182,7 @@ def test_interactive_deposit_no_token(client):
     response.
     """
     response = client.get(WEBAPP_PATH)
-    assert "Missing authentication token" in response.content.decode()
+    assert "Missing authentication token" in str(response.content)
     assert response.status_code == 403
 
 


### PR DESCRIPTION
resolves stellar/django-polaris#299

This makes the interactive JWT used a one-time token. If included in the URL of an interactive webapp GET request after being authenticated in a prior GET request, the server should reject the token. This ensures only one window can be opened.