### PR TITLE
Replace loading distribution account on startup with on-demand in-memory loading

### DIFF
--- a/polaris/polaris/apps.py
+++ b/polaris/polaris/apps.py
@@ -1,5 +1,3 @@
-import json
-from datetime import timedelta
 from django.apps import AppConfig
 
 

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -52,8 +52,8 @@ def execute_deposit(transaction: Transaction) -> bool:
 def check_for_multisig(transaction):
     master_signer = None
     if transaction.asset.distribution_account_master_signer:
-        master_signer = json.loads(transaction.asset.distribution_account_master_signer)
-    thresholds = json.loads(transaction.asset.distribution_account_thresholds)
+        master_signer = transaction.asset.distribution_account_master_signer
+    thresholds = transaction.asset.distribution_account_thresholds
     if not (master_signer and master_signer["weight"] >= thresholds["med_threshold"]):
         # master account is not sufficient
         transaction.pending_signatures = True

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -159,6 +159,10 @@ class Command(BaseCommand):
         for transaction in ready_transactions:
             if module.TERMINATE:
                 break
+            elif transaction.kind != Transaction.KIND.deposit:
+                raise CommandError(
+                    "A non-deposit Transaction was returned from poll_pending_deposits()"
+                )
             elif transaction.amount_in is None:
                 raise CommandError(
                     "poll_pending_deposits() did not assign a value to the "

--- a/polaris/polaris/migrations/0003_auto_20201009_1300.py
+++ b/polaris/polaris/migrations/0003_auto_20201009_1300.py
@@ -14,9 +14,6 @@ class Migration(migrations.Migration):
         ),
         migrations.RemoveField(model_name="asset", name="distribution_account_signers"),
         migrations.RemoveField(
-            model_name="asset", name="distribution_account_signer_weights"
-        ),
-        migrations.RemoveField(
             model_name="asset", name="distribution_account_thresholds"
         ),
     ]

--- a/polaris/polaris/migrations/0003_auto_20201009_1300.py
+++ b/polaris/polaris/migrations/0003_auto_20201009_1300.py
@@ -9,9 +9,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="asset",
-            name="updated_at",
-            field=models.DateTimeField(default=polaris.models.utc_now),
+        migrations.RemoveField(
+            model_name="asset", name="distribution_account_master_signer"
+        ),
+        migrations.RemoveField(model_name="asset", name="distribution_account_signers"),
+        migrations.RemoveField(
+            model_name="asset", name="distribution_account_signer_weights"
+        ),
+        migrations.RemoveField(
+            model_name="asset", name="distribution_account_thresholds"
         ),
     ]

--- a/polaris/polaris/migrations/0003_auto_20201009_1300.py
+++ b/polaris/polaris/migrations/0003_auto_20201009_1300.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+import polaris.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("polaris", "0002_auto_20200921_2135"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="asset",
+            name="updated_at",
+            field=models.DateTimeField(default=polaris.models.utc_now),
+        ),
+    ]

--- a/polaris/polaris/models.py
+++ b/polaris/polaris/models.py
@@ -242,6 +242,13 @@ class Asset(TimeStampedModel):
     the account's public key, if present.
     """
 
+    updated_at = models.DateTimeField(default=utc_now)
+    """
+    Updated on every instance ``.save()`` call. Note that multi-object write
+    queries do not call ``.save()``, such as ``Asset.objects.update(...)``.
+    This means such queries must include the a value for ``update_at``.
+    """
+
     objects = models.Manager()
 
     @property
@@ -252,6 +259,14 @@ class Asset(TimeStampedModel):
         if not self.distribution_seed:
             return None
         return Keypair.from_secret(str(self.distribution_seed)).public_key
+
+    def save(self, *args, **kwargs):
+        """
+        Writes any changes made to the model instance in memory to the
+        database. Explictly updates ``updated_at``.
+        """
+        self.updated_at = utc_now()
+        super().save(*args, **kwargs)
 
     class Meta:
         app_label = "polaris"

--- a/polaris/polaris/models.py
+++ b/polaris/polaris/models.py
@@ -27,12 +27,6 @@ from stellar_sdk.transaction_envelope import TransactionEnvelope
 from stellar_sdk.exceptions import SdkError
 
 
-# This dictionary acts as an in-memory indication of whether or not
-# the Asset object's distribution account fields have been updated
-# since this process started.
-ASSET_DISTRIBUTION_ACCOUNT_LOADED = {}
-
-
 def utc_now():
     return datetime.datetime.now(datetime.timezone.utc)
 

--- a/polaris/polaris/models.py
+++ b/polaris/polaris/models.py
@@ -90,6 +90,17 @@ class EncryptedTextField(models.TextField):
 
 
 class Asset(TimeStampedModel):
+    def __init__(self, *args, **kwargs):
+        self._distribution_account_signers = kwargs.pop(
+            "distribution_account_signers", None
+        )
+        self._distribution_account_master_signer = kwargs.pop(
+            "distribution_account_master_signer", None
+        )
+        self._distribution_account_thresholds = kwargs.pop(
+            "distribution_account_thresholds", None
+        )
+        super().__init__(*args, **kwargs)
 
     code = models.TextField()
     """The asset code as defined on the Stellar network."""
@@ -257,8 +268,8 @@ class Asset(TimeStampedModel):
             f is not None
             for f in [
                 self._distribution_account_master_signer,
-                self.distribution_account_signers,
-                self.distribution_account_thresholds,
+                self._distribution_account_signers,
+                self._distribution_account_thresholds,
             ]
         )
 
@@ -270,12 +281,12 @@ class Asset(TimeStampedModel):
             .account_id(account_id=self.distribution_account)
             .call()
         )
-        self._distribution_account_signers = account_json["signers"]
-        self._distribution_account_thresholds = account_json["thresholds"]
+        self._distribution_account_signers = json.dumps(account_json["signers"])
+        self._distribution_account_thresholds = json.dumps(account_json["thresholds"])
         self._distribution_account_master_signer = None
         for s in account_json["signers"]:
             if s["key"] == self.distribution_account:
-                self._distribution_account_master_signer = s
+                self._distribution_account_master_signer = json.dumps(s)
                 break
 
     class Meta:

--- a/polaris/polaris/models.py
+++ b/polaris/polaris/models.py
@@ -223,13 +223,6 @@ class Asset(TimeStampedModel):
     symbol = models.TextField(default="$")
     """The symbol used in HTML pages when displaying amounts of this asset"""
 
-    updated_at = models.DateTimeField(default=utc_now)
-    """
-    Updated on every instance ``.save()`` call. Note that multi-object write
-    queries do not call ``.save()``, such as ``Asset.objects.update(...)``.
-    This means such queries must include the a value for ``update_at``.
-    """
-
     objects = models.Manager()
 
     @property

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -32,10 +32,6 @@ elif hasattr(settings, "POLARIS_ENV_PATH"):
             f"Could not find env file at {settings.POLARIS_ENV_PATH}"
         )
 
-REFRESH_ASSETS_ON_STARTUP = (
-    env_or_settings("REFRESH_ASSETS_ON_STARTUP", bool=True) or False
-)
-
 SIGNING_SEED, SIGNING_KEY = None, None
 if "sep-10" in settings.POLARIS_ACTIVE_SEPS:
     SIGNING_SEED = env_or_settings("SIGNING_SEED")

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -32,6 +32,10 @@ elif hasattr(settings, "POLARIS_ENV_PATH"):
             f"Could not find env file at {settings.POLARIS_ENV_PATH}"
         )
 
+REFRESH_ASSETS_ON_STARTUP = (
+    env_or_settings("REFRESH_ASSETS_ON_STARTUP", bool=True) or False
+)
+
 SIGNING_SEED, SIGNING_KEY = None, None
 if "sep-10" in settings.POLARIS_ACTIVE_SEPS:
     SIGNING_SEED = env_or_settings("SIGNING_SEED")

--- a/polaris/polaris/tests/conftest.py
+++ b/polaris/polaris/tests/conftest.py
@@ -31,22 +31,22 @@ def fixture_usd_asset_factory():
         Creates a test USD asset that composes the example /info response, according
         to https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#response-2
         """
+        signer = {
+            "key": Keypair.from_secret(USD_DISTRIBUTION_SEED).public_key,
+            "weight": 1,
+            "type": "ed25519_public_key",
+        }
         if not protocols:
             protocols = [Transaction.PROTOCOL.sep24]
         usd_asset = Asset(
             code="USD",
             issuer=USD_ISSUER_ACCOUNT,
             distribution_seed=USD_DISTRIBUTION_SEED,
-            distribution_account_signers=json.dumps(
-                {
-                    "key": Keypair.from_secret(USD_DISTRIBUTION_SEED).public_key,
-                    "weight": 1,
-                    "type": "ed25519_public_key",
-                }
-            ),
+            distribution_account_signers=json.dumps([signer]),
             distribution_account_thresholds=json.dumps(
                 {"low_threshold": 0, "med_threshold": 1, "high_threshold": 1}
             ),
+            distribution_account_master_signer=json.dumps(signer),
             significant_decimals=2,
             # Deposit Info
             deposit_enabled=True,
@@ -75,6 +75,16 @@ def fixture_usd_asset_factory():
     return create_usd_asset
 
 
+@pytest.fixture(scope="session", autouse=True)
+def fixture_no_asset_distribution_account_updates():
+    from polaris import models
+
+    tmp = models.Asset.load_distribution_account_data
+    models.Asset.load_distribution_account_data = Mock()
+    yield  # run tests, then in cleanup:
+    models.Asset.load_distribution_account_data = tmp
+
+
 @pytest.fixture(scope="session", name="eth_asset_factory")
 def fixture_eth_asset_factory():
     """Factory method fixture to populate the test database with an ETH asset."""
@@ -84,22 +94,22 @@ def fixture_eth_asset_factory():
         Creates a test ETH asset that composes the example /info response, according
         to https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#response-2
         """
+        signer = {
+            "key": Keypair.from_secret(ETH_DISTRIBUTION_SEED).public_key,
+            "weight": 1,
+            "type": "ed25519_public_key",
+        }
         if not protocols:
             protocols = [Transaction.PROTOCOL.sep24]
         eth_asset = Asset(
             code="ETH",
             issuer=ETH_ISSUER_ACCOUNT,
             distribution_seed=ETH_DISTRIBUTION_SEED,
-            distribution_account_signers=json.dumps(
-                {
-                    "key": Keypair.from_secret(USD_DISTRIBUTION_SEED).public_key,
-                    "weight": 1,
-                    "type": "ed25519_public_key",
-                }
-            ),
+            distribution_account_signers=json.dumps([signer]),
             distribution_account_thresholds=json.dumps(
                 {"low_threshold": 0, "med_threshold": 1, "high_threshold": 1}
             ),
+            distribution_account_master_signer=json.dumps(signer),
             # Deposit Info
             deposit_enabled=True,
             deposit_fee_fixed=0.002,

--- a/polaris/polaris/tests/conftest.py
+++ b/polaris/polaris/tests/conftest.py
@@ -42,11 +42,13 @@ def fixture_usd_asset_factory():
             code="USD",
             issuer=USD_ISSUER_ACCOUNT,
             distribution_seed=USD_DISTRIBUTION_SEED,
-            distribution_account_signers=json.dumps([signer]),
-            distribution_account_thresholds=json.dumps(
-                {"low_threshold": 0, "med_threshold": 1, "high_threshold": 1}
-            ),
-            distribution_account_master_signer=json.dumps(signer),
+            distribution_account_signers=[signer],
+            distribution_account_thresholds={
+                "low_threshold": 0,
+                "med_threshold": 1,
+                "high_threshold": 1,
+            },
+            distribution_account_master_signer=signer,
             significant_decimals=2,
             # Deposit Info
             deposit_enabled=True,
@@ -105,11 +107,13 @@ def fixture_eth_asset_factory():
             code="ETH",
             issuer=ETH_ISSUER_ACCOUNT,
             distribution_seed=ETH_DISTRIBUTION_SEED,
-            distribution_account_signers=json.dumps([signer]),
-            distribution_account_thresholds=json.dumps(
-                {"low_threshold": 0, "med_threshold": 1, "high_threshold": 1}
-            ),
-            distribution_account_master_signer=json.dumps(signer),
+            distribution_account_signers=[signer],
+            distribution_account_thresholds={
+                "low_threshold": 0,
+                "med_threshold": 1,
+                "high_threshold": 1,
+            },
+            distribution_account_master_signer=signer,
             # Deposit Info
             deposit_enabled=True,
             deposit_fee_fixed=0.002,

--- a/polaris/polaris/tests/conftest.py
+++ b/polaris/polaris/tests/conftest.py
@@ -75,16 +75,6 @@ def fixture_usd_asset_factory():
     return create_usd_asset
 
 
-@pytest.fixture(scope="session", autouse=True)
-def fixture_no_asset_distribution_account_updates():
-    from polaris import models
-
-    models.hidden_update_distribution_account_data = (
-        models.update_distribution_account_data
-    )
-    models.update_distribution_account_data = Mock()
-
-
 @pytest.fixture(scope="session", name="eth_asset_factory")
 def fixture_eth_asset_factory():
     """Factory method fixture to populate the test database with an ETH asset."""

--- a/polaris/polaris/tests/processes/test_create_stellar_deposit.py
+++ b/polaris/polaris/tests/processes/test_create_stellar_deposit.py
@@ -99,18 +99,6 @@ def test_deposit_stellar_no_account(acc1_usd_deposit_transaction_factory):
     """
     deposit = acc1_usd_deposit_transaction_factory()
     deposit.status = Transaction.STATUS.pending_anchor
-    deposit.asset.distribution_account_signers = json.dumps(mock_account.signers)
-    deposit.asset.distribution_account_thresholds = json.dumps(
-        {
-            "low_threshold": mock_account.thresholds.low_threshold,
-            "med_threshold": mock_account.thresholds.med_threshold,
-            "high_threshold": mock_account.thresholds.high_threshold,
-        }
-    )
-    deposit.asset.distribution_account_master_signer = json.dumps(
-        mock_account.signers[0]
-    )
-    deposit.asset.save()
     deposit.save()
     create_stellar_deposit(deposit)
     assert mock_server_no_account.submit_transaction.was_called
@@ -148,18 +136,6 @@ def test_deposit_stellar_success(acc1_usd_deposit_transaction_factory):
     """
     deposit = acc1_usd_deposit_transaction_factory()
     deposit.status = Transaction.STATUS.pending_anchor
-    deposit.asset.distribution_account_signers = json.dumps(mock_account.signers)
-    deposit.asset.distribution_account_thresholds = json.dumps(
-        {
-            "low_threshold": mock_account.thresholds.low_threshold,
-            "med_threshold": mock_account.thresholds.med_threshold,
-            "high_threshold": mock_account.thresholds.high_threshold,
-        }
-    )
-    deposit.asset.distribution_account_master_signer = json.dumps(
-        mock_account.signers[0]
-    )
-    deposit.asset.save()
     deposit.save()
     assert create_stellar_deposit(deposit)
     assert Transaction.objects.get(id=deposit.id).status == Transaction.STATUS.completed
@@ -196,18 +172,6 @@ def test_deposit_stellar_no_trustline(acc1_usd_deposit_transaction_factory):
     """
     deposit = acc1_usd_deposit_transaction_factory()
     deposit.status = Transaction.STATUS.pending_anchor
-    deposit.asset.distribution_account_signers = json.dumps(mock_account.signers)
-    deposit.asset.distribution_account_thresholds = json.dumps(
-        {
-            "low_threshold": mock_account.thresholds.low_threshold,
-            "med_threshold": mock_account.thresholds.med_threshold,
-            "high_threshold": mock_account.thresholds.high_threshold,
-        }
-    )
-    deposit.asset.distribution_account_master_signer = json.dumps(
-        mock_account.signers[0]
-    )
-    deposit.asset.save()
     deposit.save()
     assert not create_stellar_deposit(deposit)
     assert (

--- a/polaris/polaris/tests/processes/test_poll_pending_deposits.py
+++ b/polaris/polaris/tests/processes/test_poll_pending_deposits.py
@@ -2,6 +2,8 @@ import pytest
 import json
 from unittest.mock import patch, Mock
 
+from django.core.management import CommandError
+
 from polaris.management.commands.poll_pending_deposits import Command, rdi, rri, logger
 from polaris.models import Transaction
 from polaris.tests.processes.test_create_stellar_deposit import mock_account
@@ -17,18 +19,6 @@ test_module = "polaris.management.commands.poll_pending_deposits"
 )
 def test_poll_pending_deposits_success(client, acc1_usd_deposit_transaction_factory):
     transaction = acc1_usd_deposit_transaction_factory()
-    transaction.asset.distribution_account_signers = json.dumps(mock_account.signers)
-    transaction.asset.distribution_account_thresholds = json.dumps(
-        {
-            "low_threshold": mock_account.thresholds.low_threshold,
-            "med_threshold": mock_account.thresholds.med_threshold,
-            "high_threshold": mock_account.thresholds.high_threshold,
-        }
-    )
-    transaction.asset.distribution_account_master_signer = json.dumps(
-        mock_account.signers[0]
-    )
-    transaction.asset.save()
     rri.poll_pending_deposits = Mock(return_value=[transaction])
     rdi.after_deposit = Mock()
     Command.execute_deposits()
@@ -54,32 +44,8 @@ def test_poll_pending_deposits_bad_integration(
     acc1_usd_deposit_transaction_factory()
     # integration returns withdraw transaction
     withdrawal_transaction = acc1_usd_withdrawal_transaction_factory()
-    withdrawal_transaction.asset.distribution_account_signers = json.dumps(
-        mock_account.signers
-    )
-    withdrawal_transaction.asset.distribution_account_thresholds = json.dumps(
-        {
-            "low_threshold": mock_account.thresholds.low_threshold,
-            "med_threshold": mock_account.thresholds.med_threshold,
-            "high_threshold": mock_account.thresholds.high_threshold,
-        }
-    )
-    withdrawal_transaction.asset.distribution_account_master_signer = json.dumps(
-        mock_account.signers[0]
-    )
-    withdrawal_transaction.asset.save()
     rri.poll_pending_deposits = Mock(return_value=[withdrawal_transaction])
     logger.error = Mock()
 
-    Command.execute_deposits()
-
-    # Change kind, add bad status
-    withdrawal_transaction.kind = Transaction.KIND.deposit
-    withdrawal_transaction.status = Transaction.STATUS.completed
-
-    Command.execute_deposits()
-
-    logger.error.assert_called_with(
-        f"Unexpected transaction status: {withdrawal_transaction.status}, expecting "
-        f"{Transaction.STATUS.pending_user_transfer_start} or {Transaction.STATUS.pending_anchor}."
-    )
+    with pytest.raises(CommandError):
+        Command.execute_deposits()

--- a/polaris/polaris/utils.py
+++ b/polaris/polaris/utils.py
@@ -158,8 +158,8 @@ def create_stellar_deposit(
     # medium threshold, verify the transaction is signed by it's channel account
     master_signer = None
     if transaction.asset.distribution_account_master_signer:
-        master_signer = json.loads(transaction.asset.distribution_account_master_signer)
-    thresholds = json.loads(transaction.asset.distribution_account_thresholds)
+        master_signer = transaction.asset.distribution_account_master_signer
+    thresholds = transaction.asset.distribution_account_thresholds
     if not (master_signer and master_signer["weight"] >= thresholds["med_threshold"]):
         multisig = True
         envelope = TransactionEnvelope.from_xdr(
@@ -364,10 +364,8 @@ def get_or_create_transaction_destination_account(
     except RuntimeError:
         master_signer = None
         if transaction.asset.distribution_account_master_signer:
-            master_signer = json.loads(
-                transaction.asset.distribution_account_master_signer
-            )
-        thresholds = json.loads(transaction.asset.distribution_account_thresholds)
+            master_signer = transaction.asset.distribution_account_master_signer
+        thresholds = transaction.asset.distribution_account_thresholds
         if master_signer and master_signer["weight"] >= thresholds["med_threshold"]:
             source_account_kp = Keypair.from_secret(transaction.asset.distribution_seed)
             source_account, _ = get_account_obj(source_account_kp)


### PR DESCRIPTION
resolves stellar/django-polaris#334

Polaris 1.1.0 changed `Asset` initialization to check for whether or not an in-memory cache record existed for the `Asset`'s distribution account. If no record of the asset existed in the cache, Polaris would do two things:

- Make an API call to Horizon for the asset's distribution account
- Make a DB query to save the account's signers and weights from the Horizon response

This is a bug and 1.1.0 as well as 1.1.1 will likely be removed from PyPi. Version `1.1.2` will be released with this change.