### PR TITLE
base.html title block double quotes

### DIFF
--- a/polaris/polaris/templates/polaris/base.html
+++ b/polaris/polaris/templates/polaris/base.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {% block 'title' %}
+    {% block "title" %}
     <title>{% if title %}{{ title|safe }}{% else %}{% trans "SEP24 reference server" %}{% endif %}</title>
     {% endblock %}
 


### PR DESCRIPTION
In templates which extend `base.html`, `{% block "title" %}` is not overriding `{% block 'title' %}` from `base.html`, but `{% block 'title' %}` is, so instead of using single quotes when extending, I think it's easier to stick to the double quotes pattern in the base template.