### PR TITLE
more_info.html lang improvement

### DIFF
--- a/polaris/polaris/templates/polaris/more_info.html
+++ b/polaris/polaris/templates/polaris/more_info.html
@@ -49,7 +49,7 @@
 
     <div class="info-item">
         <div class="info-label">
-            {% if transaction.status == "pending_user_transfer_start" %}
+            {% if transaction.status in ["incomplete", "pending_user_transfer_start"] %}
               {% trans "amount to be received" %}
             {% else %}
               {% trans "amount received" %}

--- a/polaris/polaris/templates/polaris/more_info.html
+++ b/polaris/polaris/templates/polaris/more_info.html
@@ -49,7 +49,7 @@
 
     <div class="info-item">
         <div class="info-label">
-            {% if transaction.status in ["incomplete", "pending_user_transfer_start"] %}
+            {% if transaction.status == "incomplete" or transaction.status == "pending_user_transfer_start" %}
               {% trans "amount to be received" %}
             {% else %}
               {% trans "amount received" %}

--- a/polaris/polaris/templates/polaris/more_info.html
+++ b/polaris/polaris/templates/polaris/more_info.html
@@ -49,7 +49,11 @@
 
     <div class="info-item">
         <div class="info-label">
-            {% trans "amount received" %}
+            {% if transaction.status == "pending_user_transfer_start" %}
+              {% trans "amount to be received" %}
+            {% else %}
+              {% trans "amount received" %}
+            {% endif %}
         </div>
         <div class="field-value">
             {{ amount_in }}
@@ -68,9 +72,9 @@
     <div class="info-item">
         <div class="info-label">
             {% if transaction.kind == "deposit" %}
-            {% trans "amount deposited" %}
+                {% trans "amount deposited" %}
             {% else %}
-            {% trans "amount withdrawn" %}
+                {% trans "amount withdrawn" %}
             {% endif %}
         </div>
         <div class="field-value">


### PR DESCRIPTION
When status is `pending_user_transfer_start`, the amount isn't received from the user yet, so it's confusing to have `Amount received` as the label:

![image](https://user-images.githubusercontent.com/26092447/98746028-71b84b00-2393-11eb-81d7-86ee10fc3d97.png)

`Amount to be received` is more appropriate in that case.