### PR TITLE
Pass 'pending_external' transaction to poll_pending_deposits()

### DIFF
--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -29,7 +29,7 @@ Polaris periodically queries for transactions in ``pending_external`` and passes
 poll_pending_deposits
 ^^^^^^^^^^^^^^^^^^^^^
 
-Polaris periodically queries for transactions in ``pending_user_transfer_start`` and ``pending_external`` and passes them to the ``RailsIntegration.poll_pending_deposits`` integration function. The anchor is expected to update the transactions' status depending on the if the funds have become available in the anchor's off-chain account or if the funds have been sent but not received. See the ``poll_pending_deposits()`` integration function for more details.
+Polaris periodically queries for transactions in ``pending_user_transfer_start`` and ``pending_external`` and passes them to the ``RailsIntegration.poll_pending_deposits`` integration function. ``Transaction`` objects that represent funds that have been received off-chain should be returned so Polaris can submit them to the Stellar network. See the ``poll_pending_deposits()`` integration function for more details.
 
 check_trustlines
 ^^^^^^^^^^^^^^^^

--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -29,7 +29,7 @@ Polaris periodically queries for transactions in ``pending_external`` and passes
 poll_pending_deposits
 ^^^^^^^^^^^^^^^^^^^^^
 
-Polaris periodically queries for transactions in ``pending_user_transfer_start`` and ``pending_sender`` and passes them to the ``RailsIntegration.poll_pending_deposits`` integration function. The anchor is expected to update the transactions' status depending on the if the funds have become available in the anchor's off-chain account.
+Polaris periodically queries for transactions in ``pending_user_transfer_start`` and ``pending_external`` and passes them to the ``RailsIntegration.poll_pending_deposits`` integration function. The anchor is expected to update the transactions' status depending on the if the funds have become available in the anchor's off-chain account or if the funds have been sent but not received. See the ``poll_pending_deposits()`` integration function for more details.
 
 check_trustlines
 ^^^^^^^^^^^^^^^^

--- a/polaris/polaris/integrations/rails.py
+++ b/polaris/polaris/integrations/rails.py
@@ -90,8 +90,8 @@ class RailsIntegration:
 
         Also ensure the amount deposited to the anchor's account matches each
         transaction's ``amount_in`` field. Client applications may send an amount
-        that differs from the amount originally specified in a SEP-24 interactive
-        form, or in the case of SEP-6 transactions, ``amount_in`` will be ``None``.
+        that differs from the amount originally specified prior.
+
         If ``amount_in`` differs from the amount deposited, assign the amount
         deposited to ``amount_in`` and update ``amount_fee`` to appropriately.
 
@@ -116,6 +116,17 @@ class RailsIntegration:
                     Transaction.STATUS.pending_external
                 ]
             )
+
+        ``pending_user_transfer_start`` is the proper status for a
+        transaction when the user must take some action to proceed. In this
+        case, that action is sending the deposit funds.
+
+        ``pending_external`` is the proper status for a transaction when
+        the deposit funds have been sent but have not arrived in the anchor's
+        off-chain account. If the anchor cannot detect when deposit funds
+        are sent but not received, it is perfectly acceptable to keep the
+        transaction in ``pending_user_transfer_start`` until the funds have
+        arrived.
 
         If you have many pending deposits, you may way want to batch
         the retrieval of these objects to improve query performance and

--- a/polaris/polaris/integrations/rails.py
+++ b/polaris/polaris/integrations/rails.py
@@ -85,13 +85,13 @@ class RailsIntegration:
         externally completed, meaning the off-chain funds are available in the
         anchor's account.
 
-        Per SEP-24, make sure to save the transaction's ``from_address`` field with
+        Make sure to save the transaction's ``from_address`` field with
         the account the funds originated from.
 
         Also ensure the amount deposited to the anchor's account matches each
         transaction's ``amount_in`` field. Client applications may send an amount
-        that differs from the amount originally specified in a SEP-24 API call,
-        or in the case of SEP-6 transactions, ``amount_in`` will be ``None``.
+        that differs from the amount originally specified in a SEP-24 interactive
+        form, or in the case of SEP-6 transactions, ``amount_in`` will be ``None``.
         If ``amount_in`` differs from the amount deposited, assign the amount
         deposited to ``amount_in`` and update ``amount_fee`` to appropriately.
 
@@ -111,7 +111,10 @@ class RailsIntegration:
 
             Transactions.object.filter(
                 kind=Transaction.KIND.deposit,
-                status=Transaction.STATUS.pending_user_transfer_start
+                status=[
+                    Transaction.STATUS.pending_user_transfer_start,
+                    Transaction.STATUS.pending_external
+                ]
             )
 
         If you have many pending deposits, you may way want to batch

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -54,7 +54,7 @@ def check_for_multisig(transaction):
     if transaction.asset.distribution_account_master_signer:
         master_signer = transaction.asset.distribution_account_master_signer
     thresholds = transaction.asset.distribution_account_thresholds
-    if not (master_signer and master_signer["weight"] >= thresholds["med_threshold"]):
+    if not master_signer or master_signer["weight"] < thresholds["med_threshold"]:
         # master account is not sufficient
         transaction.pending_signatures = True
         transaction.status = Transaction.STATUS.pending_anchor

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -136,14 +136,12 @@ class Command(BaseCommand):
 
     @classmethod
     def execute_deposits(cls):
-        """
-        Right now, execute_deposits assumes all pending deposits are SEP-6 or 24
-        transactions. This may change in the future if Polaris adds support for
-        another SEP that checks for incoming deposits.
-        """
         module = sys.modules[__name__]
         pending_deposits = Transaction.objects.filter(
-            status=Transaction.STATUS.pending_user_transfer_start,
+            status__in=[
+                Transaction.STATUS.pending_user_transfer_start,
+                Transaction.STATUS.pending_external,
+            ],
             kind=Transaction.KIND.deposit,
         )
         try:

--- a/polaris/polaris/tests/auth_test.py
+++ b/polaris/polaris/tests/auth_test.py
@@ -43,7 +43,7 @@ def test_auth_get_account(client):
 
     manage_data_op = transaction_object.operations[0]
     assert manage_data_op.type_code() == Xdr.const.MANAGE_DATA
-    assert manage_data_op.data_name == f"{urlparse(settings.HOST_URL).hostname} auth"
+    assert manage_data_op.data_name == f"{urlparse(settings.HOST_URL).netloc} auth"
     assert len(manage_data_op.data_value) <= 64
     assert len(base64.b64decode(manage_data_op.data_value)) == 48
 

--- a/polaris/polaris/tests/processes/test_poll_pending_deposits.py
+++ b/polaris/polaris/tests/processes/test_poll_pending_deposits.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 from unittest.mock import patch, Mock
 
 from django.core.management import CommandError
@@ -11,22 +10,45 @@ from polaris.tests.processes.test_create_stellar_deposit import mock_account
 test_module = "polaris.management.commands.poll_pending_deposits"
 
 
+def mock_poll_pending_deposits_success(deposits):
+    """
+    Returns deposits that are "ready"
+    pending_external deposits are not "ready" because funds have not
+    been received by the anchor.
+    """
+    return [
+        d
+        for d in deposits
+        if d.status == Transaction.STATUS.pending_user_transfer_start
+    ]
+
+
 @pytest.mark.django_db
 @patch(f"{test_module}.create_stellar_deposit", Mock(return_value=True))
 @patch(
     f"{test_module}.get_or_create_transaction_destination_account",
     Mock(return_value=(mock_account, False, False)),
 )
+@patch(f"{test_module}.check_for_multisig", Mock(return_value=False))
 def test_poll_pending_deposits_success(client, acc1_usd_deposit_transaction_factory):
-    transaction = acc1_usd_deposit_transaction_factory()
-    rri.poll_pending_deposits = Mock(return_value=[transaction])
+    transaction_user = acc1_usd_deposit_transaction_factory()
+    transaction_external = acc1_usd_deposit_transaction_factory()
+    transaction_external.status = Transaction.STATUS.pending_external
+    transaction_external.save()
+    og_pending_deposits = rri.poll_pending_deposits
+    rri.poll_pending_deposits = mock_poll_pending_deposits_success
     rdi.after_deposit = Mock()
     Command.execute_deposits()
-    transaction.refresh_from_db()
-    assert transaction.status == Transaction.STATUS.pending_anchor
-    assert transaction.status_eta == 5
+
+    transaction_user.refresh_from_db()
+    assert transaction_user.status == Transaction.STATUS.pending_anchor
+    assert transaction_user.status_eta == 5
     assert rdi.after_deposit.was_called
-    assert rri.poll_pending_deposits.was_called
+
+    transaction_external.refresh_from_db()
+    assert transaction_external.status == Transaction.STATUS.pending_external
+
+    rri.poll_pending_deposits = og_pending_deposits
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
resolves stellar/django-polaris#324

Adds `pending_external` `Transaction` objects to the `poll_pending_deposits()` call. This allows anchors to periodically check on transactions they know are en-route but funds have not been received. Prior, anchors were forced to leave these transactions in `pending_user_transfer_start`, which may have confused the user.

Also fixes a test bug where we check the SEP10 domain using `urllib.parse.urlparse`s `hostname` attribute instead of `netloc`.