### PR TITLE
Match Path Payments from Clients

### DIFF
--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -9,7 +9,7 @@ Implementing SEP 6, 24, or 31 requires more than a web server. Anchors must also
 
 To support these requirements, Polaris deployments must also include additional services to run alongside the web server. The SDF currently deploys Polaris using its CLI commands. Each command either periodically checks external state or constantly streams events from an external data source.
 
-With the exception of ``watch_transactions``, every CLI command can be run once or repeatedly on some interval using the ``--loop`` and ``--interval <seconds>`` arguments. These commands should either be run by a job scheduler like Jenkins and CircleCI or run with the ``--loop`` argument.
+With the exception of ``watch_transactions`` and ``testnet``, every CLI command can be run once or repeatedly on some interval using the ``--loop`` and ``--interval <seconds>`` arguments. These commands should either be run by a job scheduler like Jenkins and CircleCI or run with the ``--loop`` argument.
 
 watch_transactions
 ^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ This process streams transactions to and from each anchored asset's distribution
 execute_outgoing_transactions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This process periodically queries for transactions that are ready to be executed off-chain and calls Polaris' ``RailsIntegration.execute_outgoing_transaction`` integration function for each one. "Ready" transactions are those in ``pending_receiver`` or ``pending_anchor`` statuses, among other conditions. Anchor are expected to update the ``Transaction.status`` to ``completed`` or ``pending_external`` if initiating the transfer was successful.
+This process periodically queries for transactions that are ready to be executed off-chain and calls Polaris' ``RailsIntegration.execute_outgoing_transaction`` integration function for each one. "Ready" transactions are those in ``pending_receiver`` or ``pending_anchor`` statuses, among other conditions. Anchors are expected to update the ``Transaction.status`` to ``completed`` or ``pending_external`` if initiating the transfer was successful.
 
 poll_outgoing_transactions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/polaris/polaris/management/commands/watch_transactions.py
+++ b/polaris/polaris/management/commands/watch_transactions.py
@@ -267,7 +267,11 @@ class Command(BaseCommand):
         elif isinstance(operation, PathPaymentStrictSend):
             # since the dest amount is not specified in a strict-send op,
             # we need to get the dest amount from the operation's result
-            values["amount"] = str(op_result.success.last.amount)
+            #
+            # this method of fetching amounts gives the "raw" amount, so
+            # we need to divide by Operation._ONE: 10000000
+            # (Stellar uses 7 decimals places of precision)
+            values["amount"] = str(op_result.success.last.amount / Operation._ONE)
             values["code"] = operation.dest_asset.code
             values["issuer"] = operation.dest_asset.issuer
         elif isinstance(operation, PathPaymentStrictReceive):

--- a/polaris/polaris/management/commands/watch_transactions.py
+++ b/polaris/polaris/management/commands/watch_transactions.py
@@ -271,7 +271,9 @@ class Command(BaseCommand):
             # this method of fetching amounts gives the "raw" amount, so
             # we need to divide by Operation._ONE: 10000000
             # (Stellar uses 7 decimals places of precision)
-            values["amount"] = str(op_result.success.last.amount / Operation._ONE)
+            values["amount"] = str(
+                Decimal(op_result.success.last.amount) / Operation._ONE
+            )
             values["code"] = operation.dest_asset.code
             values["issuer"] = operation.dest_asset.issuer
         elif isinstance(operation, PathPaymentStrictReceive):

--- a/polaris/polaris/management/commands/watch_transactions.py
+++ b/polaris/polaris/management/commands/watch_transactions.py
@@ -209,9 +209,9 @@ class Command(BaseCommand):
     ) -> Optional[Dict]:
         payment_data = cls._get_payment_values(operation, op_result)
         if (
-            str(payment_data["destination"]) == want_asset.distribution_account
-            and str(payment_data["code"]) == want_asset.code
-            and str(payment_data["issuer"]) == want_asset.issuer
+            payment_data["destination"] == want_asset.distribution_account
+            and payment_data["code"] == want_asset.code
+            and payment_data["issuer"] == want_asset.issuer
         ):
             return payment_data
         else:

--- a/polaris/polaris/tests/processes/test_watch_transactions.py
+++ b/polaris/polaris/tests/processes/test_watch_transactions.py
@@ -67,6 +67,8 @@ def test_process_response_success(client):
     assert transaction.status_eta == 0
     assert transaction.paging_token
     assert transaction.status == Transaction.STATUS.pending_anchor
+    assert transaction.amount_in == 10000
+    assert False
 
 
 @pytest.mark.django_db
@@ -99,6 +101,7 @@ def test_process_response_strict_send_success(client):
     assert transaction.status_eta == 0
     assert transaction.paging_token
     assert transaction.status == Transaction.STATUS.pending_receiver
+    assert transaction.amount_in == 1001
 
 
 def test_process_response_unsuccessful(client, acc1_usd_withdrawal_transaction_factory):

--- a/polaris/polaris/tests/processes/test_watch_transactions.py
+++ b/polaris/polaris/tests/processes/test_watch_transactions.py
@@ -1,55 +1,66 @@
 import pytest
-from unittest.mock import patch, Mock
 from copy import deepcopy
+from uuid import uuid4
 
 from stellar_sdk.keypair import Keypair
+from stellar_sdk.transaction_envelope import TransactionEnvelope
 
-from polaris.models import Transaction
+from polaris import settings
+from polaris.models import Transaction, Asset
 from polaris.management.commands.watch_transactions import Command
-from polaris.tests.conftest import USD_ISSUER_ACCOUNT, USD_DISTRIBUTION_SEED
 
 test_module = "polaris.management.commands.watch_transactions"
-TRANSACTION_JSON = {
-    "id": "",
+SUCCESS_PAYMENT_TRANSACTION_JSON = {
+    "id": "57544d839c3b172a5a6651630115e5189f5a7436ddcb8ce2bece14e908f156c5",
     "successful": True,
-    "envelope_xdr": "",
+    "envelope_xdr": "AAAAAgAAAAC9noEAfpBm3DqDuP3xkGv//x/LagoUP8LaImCenYwrKAAAAGQAByFhAAAAAwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAADRA2v7e/0dICoolPpt+5L+v45drrxXm4r3H+S8fQdfngAAAAFURVNUAAAAAL2egQB+kGbcOoO4/fGQa///H8tqChQ/wtoiYJ6djCsoAAAAF0h26AAAAAAAAAAAAZ2MKygAAABAGYFWPSC205xgP1UjSHftcBp2N06shrZYfRcjr8ekHsf6iK/+7uWPw0adncxgOmy2oMGbdFi+ZH+MGrAKDY8WCg==",
+    "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
     "memo": "AAAAAAAAAAAAAAAAAAAAAIDqc+oB00EajZzqIpme754=",
     "memo_type": "hash",
-    "source": "GCUZ6YLL5RQBTYLTTQLPCM73C5XAIUGK2TIMWQH7HPSGWVS2KJ2F3CHS",
-    "paging_token": "123456789",
+    "source": "GBS3BTGSJJYD6OHHRRJXDREG67225BLTJC56Y3HX3DDJH2N5D7B3A23V",
+    "paging_token": "2007270145658880",
 }
-mock_envelope = Mock(
-    transaction=Mock(
-        operations=[
-            Mock(
-                asset=Mock(issuer=USD_ISSUER_ACCOUNT, code="USD",),
-                amount=50,
-                destination=Keypair.from_secret(USD_DISTRIBUTION_SEED).public_key,
-                type_code=Mock(return_value=1),
-                source="GCUZ6YLL5RQBTYLTTQLPCM73C5XAIUGK2TIMWQH7HPSGWVS2KJ2F3CHS",
-            )
-        ],
-        source=Keypair.from_public_key(
-            "GCUZ6YLL5RQBTYLTTQLPCM73C5XAIUGK2TIMWQH7HPSGWVS2KJ2F3CHS"
-        ),
-    )
+FAILURE_PAYMENT_TRANSACTION_JSON = {
+    "id": "",
+    "successful": False,
+    "memo": "AAAAAAAAAAAAAAAAAAAAAIDqc+oB00EajZzqIpme754=",
+    "memo_type": "hash",
+    "source": "GBS3BTGSJJYD6OHHRRJXDREG67225BLTJC56Y3HX3DDJH2N5D7B3A23V",
+    "paging_token": "",
+}
+TEST_ASSET_ISSUER_SEED = "SADPW3NKRUNSNKXZ3UCNKF5QKXFS3IBNDLIEDV4PEDLIXBXJOGSOQW6J"
+TEST_ASSET_ISSUER_PUBLIC_KEY = Keypair.from_secret(TEST_ASSET_ISSUER_SEED).public_key
+TEST_ASSET_DISTRIBUTION_SEED = (
+    "SBYMIF4ZEVMDF4JTLKLKZNJW4TGO4XBQK6UGLRY4XSWMNIFY4KHG5XKD"
 )
+TEST_ASSET_DISTRIBUTION_PUBLIC_KEY = Keypair.from_secret(
+    TEST_ASSET_DISTRIBUTION_SEED
+).public_key
 
 
 @pytest.mark.django_db
-@patch(f"{test_module}.TransactionEnvelope.from_xdr", return_value=mock_envelope)
-def test_process_response_success(
-    mock_xdr, client, acc1_usd_withdrawal_transaction_factory
-):
-    del mock_xdr
-    mock_source_account = mock_envelope.transaction.source.public_key
-    transaction = acc1_usd_withdrawal_transaction_factory(mock_source_account)
-    json = deepcopy(TRANSACTION_JSON)
-    json["successful"] = True
-    json["id"] = transaction.id
-    json["memo"] = transaction.memo
+def test_process_response_success(client):
+    """
+    Tests successful processing of the SUCCESS_PAYMENT_TRANSACTION_JSON
+    """
+    asset = Asset.objects.create(
+        code="TEST",
+        issuer=TEST_ASSET_ISSUER_PUBLIC_KEY,
+        distribution_seed=TEST_ASSET_DISTRIBUTION_SEED,
+    )
+    transaction = Transaction.objects.create(
+        asset=asset,
+        stellar_account=Keypair.random().public_key,
+        amount_in=10000,
+        kind=Transaction.KIND.withdrawal,
+        status=Transaction.STATUS.pending_user_transfer_start,
+        memo=SUCCESS_PAYMENT_TRANSACTION_JSON["memo"],
+        protocol=Transaction.PROTOCOL.sep24,
+        receiving_anchor_account=TEST_ASSET_DISTRIBUTION_PUBLIC_KEY,
+    )
+    json = deepcopy(SUCCESS_PAYMENT_TRANSACTION_JSON)
 
-    Command.process_response(json, None)
+    Command.process_response(json, TEST_ASSET_DISTRIBUTION_PUBLIC_KEY)
 
     transaction.refresh_from_db()
     assert transaction.from_address
@@ -59,13 +70,12 @@ def test_process_response_success(
     assert transaction.status == Transaction.STATUS.pending_anchor
 
 
-@pytest.mark.django_db
-@patch(f"{test_module}.TransactionEnvelope.from_xdr", return_value=mock_envelope)
+"""@pytest.mark.django_db
 def test_process_response_unsuccessful(
-    mock_xdr, client, acc1_usd_withdrawal_transaction_factory
+    client, acc1_usd_withdrawal_transaction_factory
 ):
-    del mock_xdr
-    mock_source_account = mock_envelope.transaction.source.public_key
+    envelope = TransactionEnvelope.from_xdr(TRANSACTION_JSON["envelope_xdr"], settings.STELLAR_NETWORK_PASSPHRASE)
+    mock_source_account = envelope.transaction.source.public_key
     transaction = acc1_usd_withdrawal_transaction_factory(mock_source_account)
     json = deepcopy(TRANSACTION_JSON)
     json["successful"] = False
@@ -100,4 +110,4 @@ def test_match_with_no_amount(
 
     transaction.refresh_from_db()
     assert transaction.status == Transaction.STATUS.pending_anchor
-    assert transaction.amount_in == 50
+    assert transaction.amount_in == 50"""

--- a/polaris/polaris/tests/processes/test_watch_transactions.py
+++ b/polaris/polaris/tests/processes/test_watch_transactions.py
@@ -68,7 +68,6 @@ def test_process_response_success(client):
     assert transaction.paging_token
     assert transaction.status == Transaction.STATUS.pending_anchor
     assert transaction.amount_in == 10000
-    assert False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
resolves stellar/django-polaris#355

The issue describes the problem better, but basically we need to support matching streamed payments in all forms, not just via payment operations. So I added support for matching path payment ops, both strict send and strict receive.