### PR TITLE
Add transaction fee limit env variable

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -156,6 +156,11 @@ STELLAR_NETWORK_PASSHRASE
     Defaults to ``Test SDF Network ; September 2015``.
     Ex. ``STELLAR_NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"``
 
+MAX_TRANSACTION_FEE_STROOPS
+    An integer limit for submitting Stellar transactions. Increasing this will decrease the probability of Horizon rejecting a transaction due to a [Timeout Error](https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/timeout), which means the Stellar Network selected transactions offering higher fees.
+    Defaults to the return value Python SDK's ``Server().fetch_base_fee()`` [source](https://github.com/StellarCN/py-stellar-base/blob/275d9cb7c679801b4452597c0bc3994a2779096f/stellar_sdk/server.py#L530), which is the most recent ledger's base fee, usually 100.
+    Ex. ``MAX_TRANSACTION_FEE_STROOPS=300``
+
 Polaris also supports specifying your environment variables in your project's settings file. However, any variable Polaris expects in the environment must be prepended with ``POLARIS_`` if declared in ``settings.py``. For example,
 ::
 

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -132,7 +132,8 @@ def get_or_create_transaction_destination_account(
             source_account=source_account,
             network_passphrase=settings.STELLAR_NETWORK_PASSPHRASE,
             # this transaction contains one operation so base_fee will be multiplied by 1
-            base_fee=settings.MAX_TRANSACTION_FEE_STROOPS,
+            base_fee=settings.MAX_TRANSACTION_FEE_STROOPS
+            or settings.HORIZON_SERVER.fetch_base_fee(),
         )
         transaction_envelope = builder.append_create_account_op(
             destination=transaction.stellar_account,

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -128,11 +128,11 @@ def get_or_create_transaction_destination_account(
             source_account_kp = Keypair.from_secret(transaction.channel_seed)
             source_account, _ = get_account_obj(source_account_kp)
 
-        base_fee = settings.HORIZON_SERVER.fetch_base_fee()
         builder = TransactionBuilder(
             source_account=source_account,
             network_passphrase=settings.STELLAR_NETWORK_PASSPHRASE,
-            base_fee=base_fee,
+            # this transaction contains one operation so base_fee will be multiplied by 1
+            base_fee=settings.MAX_TRANSACTION_FEE_STROOPS,
         )
         transaction_envelope = builder.append_create_account_op(
             destination=transaction.stellar_account,

--- a/polaris/polaris/management/commands/testnet.py
+++ b/polaris/polaris/management/commands/testnet.py
@@ -1,5 +1,4 @@
 import urllib3
-from math import ceil
 from decimal import Decimal
 from typing import Optional
 from logging import getLogger

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -10,12 +10,14 @@ from stellar_sdk.server import Server
 from stellar_sdk.keypair import Keypair
 
 
-def env_or_settings(variable, bool=False, list=False):
+def env_or_settings(variable, bool=False, list=False, int=False):
     try:
         if bool:
             return env.bool(variable)
         elif list:
             return env.list(variable)
+        elif int:
+            return env.int(variable)
         else:
             return env(variable)
     except ImproperlyConfigured:
@@ -73,6 +75,8 @@ SEP10_HOME_DOMAINS = env_or_settings("SEP10_HOME_DOMAINS", list=True) or [
 ]
 if any(d.startswith("http") for d in SEP10_HOME_DOMAINS):
     raise ImproperlyConfigured("SEP10_HOME_DOMAINS must only be hostnames")
+
+MAX_TRANSACTION_FEE_STROOPS = env_or_settings("BASE_FEE_MULTIPLIER", int=True)
 
 # Constants
 OPERATION_DEPOSIT = "deposit"

--- a/polaris/polaris/utils.py
+++ b/polaris/polaris/utils.py
@@ -246,7 +246,8 @@ def create_transaction_envelope(transaction, source_account) -> TransactionEnvel
         source_account=source_account,
         network_passphrase=settings.STELLAR_NETWORK_PASSPHRASE,
         # only one operation, so base_fee will be multipled by 1
-        base_fee=settings.MAX_TRANSACTION_FEE_STROOPS,
+        base_fee=settings.MAX_TRANSACTION_FEE_STROOPS
+        or settings.HORIZON_SERVER.fetch_base_fee(),
     )
     _, json_resp = get_account_obj(Keypair.from_public_key(transaction.stellar_account))
     if transaction.claimable_balance_supported and is_pending_trust(

--- a/polaris/polaris/utils.py
+++ b/polaris/polaris/utils.py
@@ -242,11 +242,11 @@ def create_transaction_envelope(transaction, source_account) -> TransactionEnvel
         transaction.asset.significant_decimals,
     )
     memo = make_memo(transaction.memo, transaction.memo_type)
-    base_fee = settings.HORIZON_SERVER.fetch_base_fee()
     builder = TransactionBuilder(
         source_account=source_account,
         network_passphrase=settings.STELLAR_NETWORK_PASSPHRASE,
-        base_fee=base_fee,
+        # only one operation, so base_fee will be multipled by 1
+        base_fee=settings.MAX_TRANSACTION_FEE_STROOPS,
     )
     _, json_resp = get_account_obj(Keypair.from_public_key(transaction.stellar_account))
     if transaction.claimable_balance_supported and is_pending_trust(


### PR DESCRIPTION
resolves #366 

- Adds a `MAX_TRANSACTION_FEE_STROOPS` environment variable
- Updates all instances of building transactions with the updated fee calculation logic

The reason I didn't make changes to resubmit rejected transactions is I learned from [the docs](https://www.stellar.org/developers/horizon/reference/errors/timeout.html) that a transaction is considered for 3 consecutive ledgers before being rejected, so one request is like getting 3 attempts anyway. It is also expensive on a synchronous system to retry requests that can take a long time to return.