### PR TITLE
Simplify & improve submit transaction logic

### DIFF
--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -333,6 +333,11 @@ class DepositIntegration:
         Stellar account `that does not require multiple signatures`, and save the secret key
         of the created account to ``transaction.channel_seed``.
 
+        This channel account must only be used as the source account for transactions related to the
+        ``Transaction`` object passed. It also must not be used to submit transactions by any service
+        other than Polaris. If it is, the outstanding transactions will be invalidated due to bad
+        sequence numbers.
+
         If this integration function is called, the deposit payment represented by ``transaction``
         requires multiple signatures in order to be successfully submitted to the Stellar network.
         The anchored asset's distribution account may or may not be in that set of signatures

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -90,40 +90,23 @@ def get_or_create_transaction_destination_account(
     transaction: Transaction,
 ) -> Tuple[Optional[Account], bool, bool]:
     """
-    Returns the stellar_sdk.account.Account for which this transaction's payment will be sent to as
-    as well as whether or not the account was created as a result of calling this function.
-
-    Args:
-        transaction (Transaction): Deposit Transaction
-
     Returns:
         Tuple[Optional[Account]: The account(s) found or created for the Transaction
-        bool: boolean to indicate if created. True if created, False otherwise.
-        bool: boolean to indicate if there isn't a trustline. True if trustline doesn't exist, False otherwise.
-
-    If the account exists, the function simply returns the account and False.
+        bool: boolean, True if created, False otherwise.
+        bool: boolean, True if trustline doesn't exist, False otherwise.
 
     If the account doesn't exist, Polaris must create the account using an account provided by the
     anchor. Polaris can use the distribution account of the anchored asset or a channel account if
     the asset's distribution account requires non-master signatures.
 
     If the transacted asset's distribution account does not require non-master signatures, Polaris
-    can create the destination account using the distribution account. On successful creation,
-    this function will return the account and True. On failure, a RuntimeError exception is raised.
+    can create the destination account using the distribution account.
 
     If the transacted asset's distribution account does require non-master signatures, the anchor
     should save a keypair of a pre-existing Stellar account to use as the channel account via
-    DepositIntegration.create_channel_account().
+    DepositIntegration.create_channel_account(). See the function docstring for more info.
 
-    This channel account must only be used as the source account for transactions related to the
-    ``Transaction`` object passed. It also must not be used to submit transactions by any service
-    other than Polaris. If it is, the outstanding transactions will be invalidated due to bad
-    sequence numbers. Finally, the channel accounts must have a master signer with a weight greater
-    than or equal to the medium threshold for the account.
-
-    After the transaction for creating the destination account has been submitted to the stellar network
-    and the transaction has been created, this function will return the account and True. If the
-    transaction was not submitted successfully, a RuntimeError exception will be raised.
+    On failure to create the destination account, a RuntimeError exception is raised.
     """
     try:
         account, json_resp = get_account_obj(

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -1,4 +1,3 @@
-import json
 import sys
 import signal
 import time
@@ -16,7 +15,7 @@ from polaris.utils import (
     create_stellar_deposit,
     create_transaction_envelope,
     get_account_obj,
-    has_trustline,
+    is_pending_trust,
 )
 from polaris.integrations import (
     registered_deposit_integration as rdi,
@@ -130,7 +129,7 @@ def get_or_create_transaction_destination_account(
         account, json_resp = get_account_obj(
             Keypair.from_public_key(transaction.stellar_account)
         )
-        return account, False, has_trustline(transaction, json_resp)
+        return account, False, is_pending_trust(transaction, json_resp)
     except RuntimeError:
         master_signer = None
         if transaction.asset.distribution_account_master_signer:

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -23,12 +23,14 @@ HORIZON_SUCCESS_RESPONSE = {
     "successful": True,
     "id": "test_stellar_id",
     "paging_token": "123456789",
+    "envelope_xdr": "",  # doesn't need to be populated, for now
 }
 HORIZON_SUCCESS_RESPONSE_CLAIM = {
     "successful": True,
     "id": "test_stellar_id",
     "paging_token": "123456789",
     "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAOAAAAAAAAAAAyBzvi/vP0Bih6bAqRNkiutMVUkW1S+WtuITJAA2LOjgAAAAA=",
+    "envelope_xdr": "",  # doesn't need to be populated for now
 }
 # Test client account and seed
 client_address = "GDKFNRUATPH4BSZGVFDRBIGZ5QAFILVFRIRYNSQ4UO7V2ZQAPRNL73RI"


### PR DESCRIPTION
resolves #361 

- removes `handle_bad_signatures_error()`, Polaris doesn't need to try and recover when multisig transactions don't have the necessary signatures; the developer marked them as ready and they weren't
- Catches 504 errors gracefully and updates the transaction status to `error`
- `submit_stellar_deposit()` now only completes or raises an error
- changes `has_trustline()` to `is_pending_trust()` to make the name reflect the value returned
- Updates comments