### PR TITLE
bug fix: don't display deposit instructions on withdraw more info page

### DIFF
--- a/example/server/templates/polaris/more_info.html
+++ b/example/server/templates/polaris/more_info.html
@@ -1,7 +1,7 @@
 {% extends "polaris/more_info.html" %} {% load i18n %}
 
 {% block "instructions" %}
-{% if transaction.status == "pending_user_transfer_start" %}
+{% if transaction.status == "pending_user_transfer_start" and transaction.kind == "deposit" %}
 
 <div class="info-item">
     <div class="info-label">

--- a/polaris/polaris/shared/endpoints.py
+++ b/polaris/polaris/shared/endpoints.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 from decimal import Decimal, DecimalException
 
 from rest_framework import status
@@ -17,6 +16,7 @@ from polaris.sep24.utils import verify_valid_asset_operation
 from polaris.shared.serializers import TransactionSerializer
 from polaris.integrations import (
     registered_deposit_integration as rdi,
+    registered_withdrawal_integration as rwi,
     registered_scripts_func,
     scripts,
 )
@@ -49,15 +49,20 @@ def more_info(request: Request, sep6: bool = False) -> Response:
         "transaction": request_transaction,
         "asset_code": request_transaction.asset.code,
     }
-    content = rdi.content_for_template(
-        Template.MORE_INFO, transaction=request_transaction
-    )
+    if request_transaction.kind == Transaction.KIND.deposit:
+        content = rdi.content_for_template(
+            Template.MORE_INFO, transaction=request_transaction
+        )
+        if request_transaction.status == Transaction.STATUS.pending_user_transfer_start:
+            context.update(
+                instructions=rdi.instructions_for_pending_deposit(request_transaction)
+            )
+    else:
+        content = rwi.content_for_template(
+            Template.MORE_INFO, transaction=request_transaction
+        )
     if content:
         context.update(content)
-    if request_transaction.status == Transaction.STATUS.pending_user_transfer_start:
-        context.update(
-            instructions=rdi.instructions_for_pending_deposit(request_transaction)
-        )
 
     if registered_scripts_func is not scripts:
         logger.warning(


### PR DESCRIPTION
This PR fixes a bug where Polaris rendered deposit instructions on a withdraw transaction's `more_info.html` page. 

Those who use the `DepositIntegration().instructions_for_pending_deposit()` function and do not validate that `transaction.kind == Transaction.KIND.deposit` are affected by this bug.

If the wallet requests a `postMessage` callback and closes the popup when one is received, then this page is never displayed to the user and there is no affect.