### PR TITLE
SEP-24: only make callback requests to opener once

### DIFF
--- a/polaris/polaris/shared/endpoints.py
+++ b/polaris/polaris/shared/endpoints.py
@@ -73,8 +73,11 @@ def more_info(request: Request, sep6: bool = False) -> Response:
         )
     context["scripts"] = registered_scripts_func(content)
 
+    # more_info.html will update the 'callback' parameter value to 'success' after
+    # making the callback. If the page is then reloaded, the callback is not included
+    # in the rendering context, ensuring only one successful callback request is made.
     callback = request.GET.get("callback")
-    if callback:
+    if callback and callback != "success":
         context["callback"] = callback
 
     return Response(context, template_name="polaris/more_info.html")

--- a/polaris/polaris/templates/polaris/more_info.html
+++ b/polaris/polaris/templates/polaris/more_info.html
@@ -112,9 +112,9 @@
     {% endif %}
 
     <script type="text/javascript">
-        // Anchors should send a POST or postMessage request with the the entire transaction
-        // object, serialized by the server, in a transaction property (i.e., the value for
-        // the "transaction" key).
+        // If requested using the 'callback' parameter, anchors should send a POST or
+        // postMessage request with the the entire transaction object, serialized by the
+        // server, in a transaction property (i.e., the value for the "transaction" key).
         //
         // In other terms, the message should have the following structure:
         // tx_json = {
@@ -124,19 +124,20 @@
         //         etc.
         //     }
         // }
-        var tx_json = JSON.parse('{{ tx_json|safe }}');
-        var transaction = tx_json["transaction"];
-        var callback = '{{ callback|safe }}'
+        let tx_json = JSON.parse('{{ tx_json|safe }}');
+        let callback = '{{ callback|safe }}'
 
-        if (!callback || callback.toLowerCase() === 'postmessage') {
+        if (callback.toLowerCase() === 'postmessage') {
             postMessageCallback();
-        } else {
+        } else if (callback) {
             urlCallback();
+        } else {
+           return
         }
 
         // Callback function to post the serialized transaction to the wallet.
         function postMessageCallback() {
-            var targetWindow;
+            let targetWindow;
 
             if (window.opener != void 0) {
                 targetWindow = window.opener;
@@ -147,6 +148,7 @@
             }
 
             targetWindow.postMessage(tx_json, "*");
+            updateURLWithCallbackSuccess();
         }
 
         // Callback function to post the serialized transaction to the callback URL
@@ -158,9 +160,16 @@
                 },
                 body: JSON.stringify(tx_json)
             }).catch((e) => {
-                console.error('POST request to specified callback failed. Attempting postMessage instead.', e);
-                postMessageCallback();
+                console.error(`POST request to ${callback} failed.`, e);
+            }).then((_) => {
+                updateURLWithCallbackSuccess();
             });
+        }
+
+        function updateURLWithCallbackSuccess() {
+            let url = URL(window.location);
+            url.searchParams.set("callback", "success");
+            window.location.pushState({}, '', url);
         }
     </script>
 </section>

--- a/polaris/polaris/templates/polaris/more_info.html
+++ b/polaris/polaris/templates/polaris/more_info.html
@@ -131,8 +131,6 @@
             postMessageCallback();
         } else if (callback) {
             urlCallback();
-        } else {
-           return
         }
 
         // Callback function to post the serialized transaction to the wallet.
@@ -167,9 +165,9 @@
         }
 
         function updateURLWithCallbackSuccess() {
-            let url = URL(window.location);
+            let url = new URL(window.location);
             url.searchParams.set("callback", "success");
-            window.location.pushState({}, '', url);
+            window.history.pushState({}, '', url);
         }
     </script>
 </section>


### PR DESCRIPTION
This PR makes Polaris compliant with SEP-24, which states that only one callback request should be made. Previously, `more_info.html` would make a callback request on every page load, if a `callback` parameter was given.