### PR TITLE
Add an explanatory command to tutorial

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -148,6 +148,10 @@ Create the database with the schema defined for Polaris.
 Then, get into the python shell and create an ``Asset`` object.
 ::
 
+    python app/manage.py shell
+
+::
+
     from polaris.models import Asset
 
     Asset.objects.create(


### PR DESCRIPTION
While setting up an anchor POC, I did not realize at first that I needed to use the `migrate.py` shell, I was just using the regular python shell and receiving errors. I think this could help explain that the user needs to perform this specific action to get into the shell with the management context loaded.