### PR TITLE
SEP-24: fix fee table updates

### DIFF
--- a/polaris/polaris/templates/polaris/base.html
+++ b/polaris/polaris/templates/polaris/base.html
@@ -153,27 +153,19 @@
 
       // Show fee and amount user will receive when amount field
       // changes, if present.
+
       let amountInput = document.querySelector('.amount-input');
       let feeTag = document.querySelector('.fee');
       let amountOutTag = document.querySelector('.amount-out');
       if (amountInput) {
         let feeTable = document.querySelector('.fee-table');
         feeTable.removeAttribute('hidden');
-        amountInput.addEventListener("input", (e) => {
+        let timeout = null;
+        amountInput.addEventListener("keyup", (e) => {
           if (isNaN(e.target.value)) return;
           let fee_fixed;
           let fee_percent;
           let amountIn = Number(e.target.value);
-          if (amountIn === 0) {
-            // The user is likely deleting all characters.
-            // Wait a bit for the last fetch() call to resolve,
-            // so its results don't overwrite this 0.
-            setTimeout(() => {
-              feeTag.innerHTML = "{{ asset.symbol }}" + "0";
-              amountOutTag.innerHTML = "{{ asset.symbol }}" + "0";
-            }, 100);
-            return;
-          }
           let op = "{{ operation }}";
           if (op === "deposit") {
             fee_fixed = {{ asset.deposit_fee_fixed|default:0 }}
@@ -183,42 +175,41 @@
             fee_percent = {{ asset.withdrawal_fee_percent|default:0 }}
           }
           let fee;
-          let amountOut;
+          function calcFee(fee, amountIn) {
+            let feeStr;
+            let amountOutStr;
+            if (Number(amountIn) !== 0) {
+              let amountOut = amountIn - fee;
+              feeStr = fee.toFixed({{ asset.significant_decimals }});
+              amountOutStr = amountOut.toFixed({{ asset.significant_decimals }});
+            } else {
+              feeStr = "0";
+              amountOutStr = "0";
+            }
+            feeTag.innerHTML = "{{ asset.symbol }}" + feeStr;
+            amountOutTag.innerHTML = "{{ asset.symbol }}" + amountOutStr;
+          }
+
           if ("{{ use_fee_endpoint }}" !== "True") {
             fee = fee_fixed + (amountIn * (fee_percent/100));
-            amountOut = amountIn - fee;
+            calcFee(fee, amountIn);
           } else {
             // Need to hit fee endpoint
-            let params = new URLSearchParams();
-            params.append("operation", op);
-            params.append("asset_code", "{{ asset.code }}");
-            params.append("amount", amountIn);
-            fetch("/sep24/fee?" + params.toString()).then(
-              response => response.json()
-            ).then(json => {
-               if (!json.error) {
-                 fee = json.fee;
-                 amountOut = amountIn - json.fee;
-               }
-            });
-          }
-          function calcFee() {
-            let feeVal = fee.toFixed({{ asset.significant_decimals }});
-            let amountOutVal = amountOut.toFixed({{ asset.significant_decimals }});
-            feeTag.innerHTML = "{{ asset.symbol }}" + ((Number(feeVal) === 0) ? "0" : feeVal);
-            amountOutTag.innerHTML = "{{ asset.symbol }}" + ((Number(amountOutVal) === 0) ? "0" : amountOutVal);
-          }
-          function waitForAmountOut() {
-            if (!amountOut) {
-              setTimeout(waitForAmountOut, 100);
-            } else {
-              calcFee();
-            }
-          }
-          if (!amountOut) {
-            setTimeout(waitForAmountOut, 100);
-          } else {
-            calcFee();
+            clearTimeout(timeout)
+            timeout = setTimeout(() => {
+              let params = new URLSearchParams({
+                "operation": op,
+                "asset_code": "{{ asset.code }}",
+                "amount": amountIn
+              });
+              fetch("/sep24/fee?" + params.toString()).then(
+                response => response.json()
+              ).then(json => {
+                 if (!json.error) {
+                   calcFee(json.fee, amountIn);
+                 }
+              });
+            }, 500);
           }
         });
       }


### PR DESCRIPTION
resolves #402

The fee table now waits until the user has not entered any input for 500 milliseconds before making an API call to the `/fee` endpoint, and will cancel any in-progress call if new input is made. 

cc @yuriescl 