### PR TITLE
SEP-24: make amount input symbol padding variable

### DIFF
--- a/polaris/polaris/templates/polaris/base.html
+++ b/polaris/polaris/templates/polaris/base.html
@@ -142,6 +142,13 @@
         })
       }
 
+      // Amount symbol padding
+      const amountInputElem = document.querySelector('.amount-input');
+      const icon = amountInputElem.previousElementSibling;
+      const iconWidthStr = getComputedStyle(icon).width;
+      const iconWidthFloat = parseFloat(iconWidthStr.replace(/px/, ''));
+      amountInputElem.style.paddingLeft = (iconWidthFloat + 2).toString() + 'px';
+
       // Disable form submit buttons after first click
       let submitButton = document.querySelector('.submit');
       let anchorForm = document.querySelector('form');
@@ -205,8 +212,8 @@
           function calcFee() {
             let feeVal = fee.toFixed({{ asset.significant_decimals }});
             let amountOutVal = amountOut.toFixed({{ asset.significant_decimals }});
-            feeTag.innerHTML = "{{ asset.symbol }}" + ((Number(feeVal) === 0) ? "0" : feeVal);
-            amountOutTag.innerHTML = "{{ asset.symbol }}" + ((Number(amountOutVal) === 0) ? "0" : amountOutVal);
+            feeTag.innerHTML = "{{ asset.symbol }} " + ((Number(feeVal) === 0) ? "0" : feeVal);
+            amountOutTag.innerHTML = "{{ asset.symbol }} " + ((Number(amountOutVal) === 0) ? "0" : amountOutVal);
           }
           function waitForAmountOut() {
             if (!amountOut) {

--- a/polaris/polaris/templates/polaris/deposit.html
+++ b/polaris/polaris/templates/polaris/deposit.html
@@ -36,8 +36,8 @@
       {% endfor %}
 
       <table class="fee-table" hidden>
-        <tr class="fee-row"><td class="fee-label">{% trans "Fee" %}</td><td class="fee">{{ asset.symbol }}0</td></tr>
-        <tr class="amount-out-row"><td class="amount-out-label">{% trans "Total" %}</td><td class="amount-out">{{ asset.symbol }}0</td></tr>
+        <tr class="fee-row"><td class="fee-label">{% trans "Fee" %}</td><td class="fee">{{ asset.symbol }} 0</td></tr>
+        <tr class="amount-out-row"><td class="amount-out-label">{% trans "Total" %}</td><td class="amount-out">{{ asset.symbol }} 0</td></tr>
       </table>
 
       <div class="field at-bottom">

--- a/polaris/polaris/templates/polaris/withdraw.html
+++ b/polaris/polaris/templates/polaris/withdraw.html
@@ -34,8 +34,8 @@
             {% endfor %}
 
             <table class="fee-table" hidden>
-                <tr class="fee-row"><td class="fee-label">{% trans "Fee" %}</td><td class="fee">{{ asset.symbol }}0</td></tr>
-                <tr class="amount-out-row"><td class="amount-out-label">{% trans "Total" %}</td><td class="amount-out">{{ asset.symbol }}0</td></tr>
+                <tr class="fee-row"><td class="fee-label">{% trans "Fee" %}</td><td class="fee">{{ asset.symbol }} 0</td></tr>
+                <tr class="amount-out-row"><td class="amount-out-label">{% trans "Total" %}</td><td class="amount-out">{{ asset.symbol }} 0</td></tr>
             </table>
 
             <div class="field">


### PR DESCRIPTION
resolves #406 

Makes the `.amount-input` element's `paddingLeft` attribute depend on the width of `.icon`. This PR also adds a space between the symbol and amount in the fee table.

cc @yuriescl  