### PR TITLE
SEP-6 & 24: save amount_fee and amount_out asap, adjust SEP-24 more_info labels

### DIFF
--- a/polaris/polaris/templates/polaris/more_info.html
+++ b/polaris/polaris/templates/polaris/more_info.html
@@ -72,9 +72,17 @@
     <div class="info-item">
         <div class="info-label">
             {% if transaction.kind == "deposit" %}
-                {% trans "amount deposited" %}
+                {% if transaction.status != "completed" and transaction.amount_out %}
+                    {% trans "amount to be deposited" %}
+                {% else %}
+                    {% trans "amount deposited" %}
+                {% endif %}
             {% else %}
-                {% trans "amount withdrawn" %}
+                {% if transaction.status != "completed" and transaction.amount_out %}
+                    {% trans "amount to be withdrawn" %}
+                {% else %}
+                    {% trans "amount withdrawn" %}
+                {% endif %}
             {% endif %}
         </div>
         <div class="field-value">


### PR DESCRIPTION
This PR changes the `example` application's behavior by calculating `Transaction.amount_fee` and `Transaction.amount_out` as soon as `Transaction.amount_in` is provided by the user.

The one change made to the Polaris library is that the SEP-24 `more_info.html` template will now use the labels `Amount To Be Deposited` and `Amount To Be Withdrawn` if `Transaction.status` is not `completed` AND a value is assigned to `Transaction.amount_out`.