### PR TITLE
only display /info amount limits if set

### DIFF
--- a/polaris/polaris/sep24/info.py
+++ b/polaris/polaris/sep24/info.py
@@ -16,11 +16,15 @@ def _get_asset_info(asset: Asset, op_type: str) -> Dict:
     if not getattr(asset, f"{op_type}_enabled"):
         return {"enabled": False}
 
-    asset_info = {
-        "enabled": True,
-        "min_amount": getattr(asset, f"{op_type}_min_amount"),
-        "max_amount": getattr(asset, f"{op_type}_max_amount"),
-    }
+    asset_info = {"enabled": True}
+    min_amount_attr = f"{op_type}_min_amount"
+    max_amount_attr = f"{op_type}_max_amount"
+    min_amount = getattr(asset, min_amount_attr)
+    max_amount = getattr(asset, max_amount_attr)
+    if min_amount > Asset._meta.get_field(min_amount_attr).default:
+        asset_info["min_amount"] = min_amount
+    if max_amount < Asset._meta.get_field(max_amount_attr).default:
+        asset_info["max_amount"] = max_amount
     if registered_fee_func is calculate_fee:
         # the anchor has not replaced the default fee function
         # so `fee_fixed` and `fee_percent` are still relevant.

--- a/polaris/polaris/sep31/info.py
+++ b/polaris/polaris/sep31/info.py
@@ -135,10 +135,14 @@ def get_asset_info(asset: Asset, fields_and_types: Dict) -> Dict:
 
     asset_info = {
         "enabled": True,
-        "min_amount": round(asset.send_min_amount, asset.significant_decimals),
-        "max_amount": round(asset.send_max_amount, asset.significant_decimals),
         **fields_and_types,
     }
+    min_amount = getattr(asset, "send_min_amount")
+    max_amount = getattr(asset, "send_max_amount")
+    if min_amount > Asset._meta.get_field("send_min_amount").default:
+        asset_info["min_amount"] = min_amount
+    if max_amount < Asset._meta.get_field("send_max_amount").default:
+        asset_info["max_amount"] = max_amount
     if asset.send_fee_fixed:
         asset_info["fee_fixed"] = round(
             asset.send_fee_fixed, asset.significant_decimals

--- a/polaris/polaris/sep6/info.py
+++ b/polaris/polaris/sep6/info.py
@@ -103,9 +103,15 @@ def get_asset_info(asset: Asset, op_type: str, fields_or_types: Dict) -> Dict:
     asset_info = {
         "enabled": True,
         "authentication_required": True,
-        "min_amount": getattr(asset, f"{op_type}_min_amount"),
-        "max_amount": getattr(asset, f"{op_type}_max_amount"),
     }
+    min_amount_attr = f"{op_type}_min_amount"
+    max_amount_attr = f"{op_type}_max_amount"
+    min_amount = getattr(asset, min_amount_attr)
+    max_amount = getattr(asset, max_amount_attr)
+    if min_amount > Asset._meta.get_field(min_amount_attr).default:
+        asset_info["min_amount"] = min_amount
+    if max_amount < Asset._meta.get_field(max_amount_attr).default:
+        asset_info["max_amount"] = max_amount
     if registered_fee_func is calculate_fee:
         # the anchor has not replaced the default fee function
         # so `fee_fixed` and `fee_percent` are still relevant.

--- a/polaris/polaris/tests/sep24/test_info.py
+++ b/polaris/polaris/tests/sep24/test_info.py
@@ -16,7 +16,6 @@ def _get_expected_response():
                 },
                 "ETH": {
                     "enabled": true,
-                    "min_amount": 0.0,
                     "max_amount": 10000000.0,
                     "fee_fixed": 0.002,
                     "fee_percent": 0.0
@@ -28,7 +27,7 @@ def _get_expected_response():
                     "min_amount": 0.1,
                     "max_amount": 1000.0,
                     "fee_fixed": 5.0,
-                    "fee_percent": 0
+                    "fee_percent": 0.0
                 },
                 "ETH": {
                     "enabled": false


### PR DESCRIPTION
resolves #421 

All SEPs implementing an `/info` endpoint (6, 24, 31) define `min_amount` and `max_amount` to be optional, but Polaris always displayed them. This ensures they are only displayed if their values are different from the default values.