### PR TITLE
SEP-24: Detect `TransactionForm.type` attribute and use in `GET /fee` requests

### DIFF
--- a/example/server/forms.py
+++ b/example/server/forms.py
@@ -26,6 +26,10 @@ class KYCForm(forms.Form):
 class WithdrawForm(TransactionForm):
     """This form accepts the amount to withdraw from the user."""
 
+    type = forms.ChoiceField(
+        choices=[(None, "--"), ("bank_account", "Bank Account")],
+        label="Transaction Type",
+    )
     bank_account = forms.CharField(
         min_length=0,
         help_text=_("Enter the bank account number for withdrawal."),

--- a/polaris/polaris/integrations/forms.py
+++ b/polaris/polaris/integrations/forms.py
@@ -82,11 +82,11 @@ class TransactionForm(forms.Form):
     A subclass of this form should be returned by
     ``form_for_transaction()`` once for each interactive flow.
 
-    After form validation, the key-value pairs in `self.cleaned_data` will be
-    passed to the registered fee function to calculate `amount_fee` for the
-    associated ``Transaction``. If you want a key-value pair passed to
-    the registered fee function but don't want to display an additional field
-    to the user, add a field with a `HiddenInput`_ widget.
+    If the default UI is used, Polaris makes calls to the anchor's `/fee` endpoint
+    and displays the response value to the user. If your `/fee` endpoint requires
+    a `type` parameter, add a ``TransactionForm.type`` attribute to the form.
+    Polaris will detect the attribute's presence on the form and include it in
+    `/fee` requests.
 
     The `amount` field is validated with the :meth:`clean_amount` function,
     which ensures the amount is within the bounds for the asset type.

--- a/polaris/polaris/templates/polaris/base.html
+++ b/polaris/polaris/templates/polaris/base.html
@@ -219,7 +219,6 @@
          * Uses timeouts to ensure a call to the /fee endpoint is only made once
          * every 500 milliseconds.
          */
-        console.log("making call");
         clearTimeout(timeout)
         timeout = setTimeout(() => {
           let params = new URLSearchParams({
@@ -243,10 +242,8 @@
       }
 
       function amountInputChange(e) {
-        console.log("event fired");
         if (isNaN(amountInput.value)) return;
         if (typeInput && !typeInput.value) {
-          console.log("type is unselected");
           return;
         }
         let fee_fixed;

--- a/polaris/polaris/templates/polaris/base.html
+++ b/polaris/polaris/templates/polaris/base.html
@@ -162,63 +162,103 @@
       // changes, if present.
 
       let amountInput = document.querySelector('.amount-input');
+      let typeInput = document.querySelector('#id_type');
       let feeTag = document.querySelector('.fee');
       let amountOutTag = document.querySelector('.amount-out');
+      let feeTable = document.querySelector('.fee-table');
+      let op = "{{ operation }}";
+      let fee_fixed;
+      let fee_percent;
+      if (op === "deposit") {
+        fee_fixed = {{ asset.deposit_fee_fixed|default:0 }}
+        fee_percent = {{ asset.deposit_fee_percent|default:0 }}
+      } else {
+        fee_fixed = {{ asset.withdrawal_fee_fixed|default:0 }}
+        fee_percent = {{ asset.withdrawal_fee_percent|default:0 }}
+      }
       if (amountInput) {
-        let feeTable = document.querySelector('.fee-table');
         feeTable.removeAttribute('hidden');
-        let timeout = null;
-        amountInput.addEventListener("keyup", (e) => {
-          if (isNaN(e.target.value)) return;
-          let fee_fixed;
-          let fee_percent;
-          let amountIn = Number(e.target.value);
-          let op = "{{ operation }}";
-          if (op === "deposit") {
-            fee_fixed = {{ asset.deposit_fee_fixed|default:0 }}
-            fee_percent = {{ asset.deposit_fee_percent|default:0 }}
-          } else {
-            fee_fixed = {{ asset.withdrawal_fee_fixed|default:0 }}
-            fee_percent = {{ asset.withdrawal_fee_percent|default:0 }}
-          }
-          let fee;
-          function calcFee(fee, amountIn) {
-            let feeStr;
-            let amountOutStr;
-            if (Number(amountIn) !== 0) {
-              let amountOut = amountIn - fee;
-              feeStr = fee.toFixed({{ asset.significant_decimals }});
-              amountOutStr = amountOut.toFixed({{ asset.significant_decimals }});
-            } else {
-              feeStr = "0";
-              amountOutStr = "0";
-            }
-            feeTag.innerHTML = "{{ asset.symbol }} " + feeStr;
-            amountOutTag.innerHTML = "{{ asset.symbol }} " + amountOutStr;
-          }
+        amountInput.addEventListener("keyup", amountInputChange);
+        typeInput.addEventListener("input", amountInputChange);
+      }
 
-          if ("{{ use_fee_endpoint }}" !== "True") {
-            fee = fee_fixed + (amountIn * (fee_percent/100));
-            calcFee(fee, amountIn);
-          } else {
-            // Need to hit fee endpoint
-            clearTimeout(timeout)
-            timeout = setTimeout(() => {
-              let params = new URLSearchParams({
-                "operation": op,
-                "asset_code": "{{ asset.code }}",
-                "amount": amountIn
-              });
-              fetch("/sep24/fee?" + params.toString()).then(
-                response => response.json()
-              ).then(json => {
-                 if (!json.error) {
-                   calcFee(json.fee, amountIn);
-                 }
-              });
-            }, 500);
+      function calcFee(fee, amountIn) {
+        /*
+         * Calculates the fee based on the amount entered and returns the strings
+         * to be rendered in the fee table.
+         */
+        let feeStr;
+        let amountOutStr;
+        if (Number(amountIn) !== 0) {
+          let amountOut = amountIn - fee;
+          feeStr = fee.toFixed({{ asset.significant_decimals }});
+          amountOutStr = amountOut.toFixed({{ asset.significant_decimals }});
+        } else {
+          feeStr = "0";
+          amountOutStr = "0";
+        }
+        return [feeStr, amountOutStr];
+      }
+
+      function updateFeeTableHtml(feeStr, amountOutStr) {
+        feeTag.innerHTML = "{{ asset.symbol }} " + feeStr;
+        amountOutTag.innerHTML = "{{ asset.symbol }} " + amountOutStr;
+      }
+
+      let timeout; // timeout must persist outside function scope
+      function callFeeEndpoint(amount) {
+        /*
+         * Calls the anchor's /fee endpoint.
+         *
+         * Note that this function may return prior to receiving a response from
+         * the server and updating the fee table's HTML.
+         *
+         * If typeInput is present but no value has been selected, this function
+         * will return without making the API call and updating the html.
+         *
+         * Uses timeouts to ensure a call to the /fee endpoint is only made once
+         * every 500 milliseconds.
+         */
+        console.log("making call");
+        clearTimeout(timeout)
+        timeout = setTimeout(() => {
+          let params = new URLSearchParams({
+            "operation": op,
+            "asset_code": "{{ asset.code }}",
+            "amount": amount
+          });
+          if (typeInput) {
+            if (!typeInput.value) return;
+            params.append('type', typeInput.value);
           }
-        });
+          fetch("/sep24/fee?" + params.toString()).then(
+            response => response.json()
+          ).then(json => {
+            if (!json.error) {
+              let [feeStr, amountOutStr] = calcFee(json.fee, amount);
+              updateFeeTableHtml(feeStr, amountOutStr);
+            }
+          });
+        }, 500);
+      }
+
+      function amountInputChange(e) {
+        console.log("event fired");
+        if (isNaN(amountInput.value)) return;
+        if (typeInput && !typeInput.value) {
+          console.log("type is unselected");
+          return;
+        }
+        let fee_fixed;
+        let fee_percent;
+        let amountIn = Number(amountInput.value);
+        if ("{{ use_fee_endpoint }}" !== "True") {
+          let fee = fee_fixed + (amountIn * (fee_percent/100));
+          let [feeStr, amountOutStr] = calcFee(fee, amountIn);
+          updateFeeTableHtml(feeStr, amountOutStr);
+        } else {
+          callFeeEndpoint(amountIn);
+        }
       }
     </script>
 


### PR DESCRIPTION
partially resolves #427

Updates the JavaScript code in `base.html` to detect a type form attribute using the `id_type` HTML ID and uses it in calls to `GET /fee`. Also updates the reference server to use the functionality and updates `TransactionForm` documentation.

cc @yuriescl 