### PR TITLE
SEP-24 added support to form hidden fields

### DIFF
--- a/polaris/polaris/templates/polaris/deposit.html
+++ b/polaris/polaris/templates/polaris/deposit.html
@@ -17,7 +17,11 @@
     <form method="post" action="{{ post_url }}">
       {% csrf_token %}
 
-      {% for field in form %}
+      {% for hidden in form.hidden_fields %}
+      {{ hidden }}
+      {% endfor %}
+
+      {% for field in form.visible_fields %}
         <div class="field">
           <label>
             <div class="label">{{ field.label }}</div>

--- a/polaris/polaris/templates/polaris/withdraw.html
+++ b/polaris/polaris/templates/polaris/withdraw.html
@@ -17,7 +17,11 @@
         <form method="post" action="{{ post_url }}">
             {% csrf_token %}
 
-            {% for field in form %}
+            {% for hidden in form.hidden_fields %}
+            {{ hidden }}
+            {% endfor %}
+
+            {% for field in form.visible_fields %}
             <div class="field">
                 <label class="label"> {{ field.label }}</label>
                 <div class="control"> {{ field }} </div>


### PR DESCRIPTION
Some Anchors might wanna use form hidden fields to identify which form is being submitted to `form_for_transaction` integration function.
For example, if there are two forms, the user fills the first one and submits it, then gets redirected to the next form, but then presses the browser back button, then submits the first form again, the Anchor can know the user is re-submitting the first form by, for example, looking at the value of a certain hidden field:

```
class WithdrawalForm0(forms.Form):
    step = forms.CharField(
        widget=forms.HiddenInput(attrs={'value': '0'}),
        required=True
    )
   ...

class WithdrawalForm1(forms.Form):
    step = forms.CharField(
        widget=forms.HiddenInput(attrs={'value': '1'}),
        required=True
    )
   ...
```