### PR TITLE
Added Nginx example configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ Production
 ^^^^^^^^^^
 
 .. _gunicorn: https://gunicorn.org
-.. _nginx configuration example: https://github.com/stellar/django-polaris/tree/master/example/nginx-letsencrypt.conf
+.. _example Nginx configuration: https://github.com/stellar/django-polaris/tree/master/example/nginx-letsencrypt.conf
 
 Polaris should only be deployed using HTTPS in production. You should do this
 by using a HTTPS web server or running Polaris behind a HTTPS reverse proxy

--- a/README.rst
+++ b/README.rst
@@ -208,9 +208,11 @@ Production
 ^^^^^^^^^^
 
 .. _gunicorn: https://gunicorn.org
+.. _nginx configuration example: https://github.com/stellar/django-polaris/tree/master/example/nginx-letsencrypt.conf
 
 Polaris should only be deployed using HTTPS in production. You should do this
-by using a HTTPS web server or running Polaris behind a HTTPS reverse proxy.
+by using a HTTPS web server or running Polaris behind a HTTPS reverse proxy
+(see `example Nginx configuration`_).
 The steps below outline the settings necessary to ensure your deployment is
 secure.
 

--- a/example/nginx-letsencrypt.conf
+++ b/example/nginx-letsencrypt.conf
@@ -1,0 +1,40 @@
+# Example configuration for Django Polaris using Nginx as reverse proxy with HTTPS enabled.
+# https://github.com/stellar/django-polaris
+
+# This configuration assumes:
+# 1) Polaris is running on localhost:8000
+# 2) Let's Encrypt Certbot was used for auto generating the SSL config lines
+
+server {
+    server_name stellar-anchor.mydomain.com;
+
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect http://localhost:8000 https://stellar-anchor.mydomain.com;
+    }
+
+    listen [::]:443 ssl ipv6only=on; # managed by Let's Encrypt Certbot
+    listen 443 ssl; # managed by Let's Encrypt Certbot
+    ssl_certificate ...; # managed by Let's Encrypt Certbot
+    ssl_certificate_key ...; # managed by Let's Encrypt Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Let's Encrypt Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Let's Encrypt Certbot
+
+}
+
+server {
+    if ($host = stellar-anchor.mydomain.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Let's Encrypt Certbot
+
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name stellar-anchor.mydomain.com;
+    return 404; # managed by Let's Encrypt Certbot
+}
+
+

--- a/example/nginx-letsencrypt.conf
+++ b/example/nginx-letsencrypt.conf
@@ -13,7 +13,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_redirect http://localhost:8000 https://stellar-anchor.mydomain.com;
     }
 
     listen [::]:443 ssl ipv6only=on; # managed by Let's Encrypt Certbot

--- a/example/nginx-letsencrypt.conf
+++ b/example/nginx-letsencrypt.conf
@@ -1,9 +1,15 @@
-# Example configuration for Django Polaris using Nginx as reverse proxy with HTTPS enabled.
-# https://github.com/stellar/django-polaris
+# Example configuration for Django Polaris (https://github.com/stellar/django-polaris)
+# using Nginx as reverse proxy with HTTPS enabled.
 
-# This configuration assumes:
-# 1) Polaris is running on localhost:8000
-# 2) Let's Encrypt Certbot was used for auto generating the SSL config lines
+# NOTE: This configuration is not used in the deployment of this example
+# application, it's here purely for reference.
+
+# This configuration has been tested with:
+# 1) Ubuntu 20.04.1 LTS
+# 2) Polaris running on localhost:8000
+# 3) Let's Encrypt Certbot was used for auto generating the SSL config lines,
+#    so there might be differences between these lines and lines generated
+#    by Certbot in other systems (Debian, RedHat, etc).
 
 server {
     server_name stellar-anchor.mydomain.com;
@@ -13,6 +19,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Situational:
+        # proxy_redirect http://localhost:8000 https://stellar-anchor.mydomain.com;
     }
 
     listen [::]:443 ssl ipv6only=on; # managed by Let's Encrypt Certbot


### PR DESCRIPTION
Anchors might need a reference configuration for Nginx. It took me some time to get it working properly, specially the HTTPS and proxy.