### PR TITLE
SEP-24: allow fees to be additive

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -248,6 +248,13 @@ SEP6_USE_MORE_INFO_URL
 
     Ex. ``SEP6_USE_MORE_INFO_URL=1``, ``SEP6_USE_MORE_INFO_URL=True``
 
+ADDITIVE_FEES_ENABLED
+    A boolean value indicating whether or not fee amounts returned from the registered fee function should be added to ``Transaction.amount_in``, the amount the user should send to the anchor. Only used for SEP-24 transactions, specifically when a ``TransactionForm`` is submitted. If this functionality is desired for SEP-6 or SEP-31 transactions, the anchor can implement the logic themselves in the provided integration functions.
+
+    Defaults to ``False``. By default, fees are subtracted from the amount initially specified by the client application or user.
+
+    Ex. ``ADDITIVE_FEES_ENABLED=1``, ``ADDITIVE_FEES_ENABLED=True``
+
 Endpoints
 ^^^^^^^^^
 

--- a/polaris/polaris/integrations/rails.py
+++ b/polaris/polaris/integrations/rails.py
@@ -45,13 +45,13 @@ class RailsIntegration:
         You could also refund a portion of the amount and continue processing the
         remaining amount. In this case, the ``transaction.status`` column should be
         assigned one of the expected statuses for this function, mentioned below, and
-        the ``amount_in`` field should be reassigned the value the anchor is accepted.
+        the ``amount_in`` field should be reassigned the value the anchor accepted.
 
         If the funds transferred to the user become available in the user's off-chain
-        account immediately, update ``Transaction.status`` to
-        ``Transaction.STATUS.completed``. If the transfer was simply initiated and is
-        pending external systems, update the status to
-        ``Transaction.STATUS.pending_external``.
+        account immediately, or the anchor cannot verify when funds have become available,
+        update ``Transaction.status`` to ``Transaction.STATUS.completed``. If the
+        transfer was simply initiated and is pending external systems, update the status
+        to ``Transaction.STATUS.pending_external``.
 
         If an exception is raised, the transaction will be left in
         its current status and may be used again as a parameter to this function.
@@ -65,7 +65,7 @@ class RailsIntegration:
         ``Transaction.required_info_update`` column. The JSON string should be in the
         format returned from ``SEP31ReceiverIntegration.info()``. You can also
         optionally save a human-readable message to
-        ``Transaction.required_info_message``. Both fields will included in the
+        ``Transaction.required_info_message``. Both fields will be included in the
         `/transaction` response requested by the sending anchor.
 
         If the SEP-31 transaction is waiting for an update, the sending anchor will

--- a/polaris/polaris/integrations/sep31.py
+++ b/polaris/polaris/integrations/sep31.py
@@ -77,6 +77,14 @@ class SEP31ReceiverIntegration:
         to your other models. If the transaction is saved but an error response is
         returned Polaris will return a 500 response to the user.
 
+        If you'd like the user to send ``Transaction.amount_in`` `plus the fee amount`,
+        add the amount charged as a fee to ``Transaction.amount_in`` here. While not
+        required per SEP-31, it is encouraged to also populate ``Transaction.amount_fee``
+        and ``Transaction.amount_out`` here as well. Note that the amount sent over the
+        Stellar Network could differ from the amount specified in this API call, so fees
+        and the amount delievered may have to be recalculated in
+        ``RailsIntegration.execute_outgoing_transaction()``.
+
         Polaris validates that the request includes all the required fields returned
         by ``SEP31ReceiverIntegration.info()`` but cannot validate the values. Return
         ``None`` if the params passed are valid, otherwise return one of the error

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -194,7 +194,7 @@ class DepositIntegration:
         ``Transaction.amount_out`` fields with the information collected. There is no
         need to implement that yourself here. However, note that if the amount
         ultimately delivered to the anchor does not match the amount specified in
-        the form, the these attributes must be updated appropriately.
+        the form, these attributes must be updated appropriately.
 
         If `form` is the last form to be served to the user, Polaris will update the
         transaction status to ``pending_user_transfer_start``, indicating that the

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -300,6 +300,14 @@ class DepositIntegration:
         if you plan to return a success response. If `transaction` is saved to the DB but a
         failure response is returned, Polaris will return a 500 error to the user.
 
+        If you'd like the user to send ``Transaction.amount_in`` `plus the fee amount`,
+        add the amount charged as a fee to ``Transaction.amount_in`` here. While not
+        required per SEP-6, it is encouraged to also populate ``Transaction.amount_fee``
+        and ``Transaction.amount_out`` here as well. Note that the amount sent over the
+        Stellar Network could differ from the amount specified in this API call, so fees
+        and the amount delievered may have to be recalculated in
+        ``RailsIntegration.execute_outgoing_transaction()``.
+
         Polaris responds to requests with the standard status code according the SEP. However,
         if you would like to return a custom error code in the range of 400-599 you may raise
         an ``rest_framework.exceptions.APIException``. For example, you could return a 503

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -190,8 +190,11 @@ class DepositIntegration:
         data in a model not used by Polaris.
 
         Keep in mind that if a ``TransactionForm`` is submitted, Polaris will
-        update the ``Transaction.amount_in`` field with the information collected.
-        There is no need to implement that yourself.
+        update the ``Transaction.amount_in``, ``Transaction.amount_fee``, and
+        ``Transaction.amount_out`` fields with the information collected. There is no
+        need to implement that yourself here. However, not that if the amount
+        ultimately delivered to the anchor does not match the amount specified in
+        the form, the these attributes must be updated appropriately.
 
         If `form` is the last form to be served to the user, Polaris will update the
         transaction status to ``pending_user_transfer_start``, indicating that the

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -192,7 +192,7 @@ class DepositIntegration:
         Keep in mind that if a ``TransactionForm`` is submitted, Polaris will
         update the ``Transaction.amount_in``, ``Transaction.amount_fee``, and
         ``Transaction.amount_out`` fields with the information collected. There is no
-        need to implement that yourself here. However, not that if the amount
+        need to implement that yourself here. However, note that if the amount
         ultimately delivered to the anchor does not match the amount specified in
         the form, the these attributes must be updated appropriately.
 

--- a/polaris/polaris/management/commands/execute_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/execute_outgoing_transactions.py
@@ -160,7 +160,10 @@ class Command(BaseCommand):
                             continue
                     else:
                         transaction.amount_fee = Decimal(0)
-                transaction.amount_out = transaction.amount_in - transaction.amount_fee
+                transaction.amount_out = round(
+                    transaction.amount_in - transaction.amount_fee,
+                    transaction.asset.significant_decimals,
+                )
                 # Anchors can mark transactions as pending_external if the transfer
                 # cannot be completed immediately due to external processing.
                 # poll_outgoing_transactions will check on these transfers and mark them

--- a/polaris/polaris/sep24/deposit.py
+++ b/polaris/polaris/sep24/deposit.py
@@ -139,7 +139,6 @@ def post_interactive_deposit(request: Request) -> Response:
                 asset.significant_decimals,
             )
             transaction.save()
-            print(transaction.amount_in, transaction.amount_fee, transaction.amount_out)
 
         rdi.after_form_validation(form, transaction)
         next_form = rdi.form_for_transaction(transaction)

--- a/polaris/polaris/settings.py
+++ b/polaris/polaris/settings.py
@@ -122,6 +122,10 @@ SEP10_CLIENT_ATTRIBUTION_DENYLIST = env_or_settings(
     "SEP10_CLIENT_ATTRIBUTION_DENYLIST", list=True, required=False
 )
 
+ADDITIVE_FEES_ENABLED = (
+    env_or_settings("ADDITIVE_FEES_ENABLED", bool=True, required=False) or False
+)
+
 # Constants
 OPERATION_DEPOSIT = "deposit"
 OPERATION_WITHDRAWAL = "withdraw"

--- a/polaris/polaris/templates/polaris/base.html
+++ b/polaris/polaris/templates/polaris/base.html
@@ -170,6 +170,7 @@
       let amountOutTag = document.querySelector('.amount-out');
       let feeTable = document.querySelector('.fee-table');
       let op = "{{ operation }}";
+      let additiveFeesEnabled = "{{ additive_fees_enabled }}" === "True";
       let fee_fixed;
       let fee_percent;
       if (op === "deposit") {
@@ -186,22 +187,22 @@
           typeInput.addEventListener("input", amountInputChange);
       }
 
-      function calcFee(fee, amountIn) {
+      function getFeeTableStrings(fee, amountIn) {
         /*
-         * Calculates the fee based on the amount entered and returns the strings
+         * Calculates the total based on the amount entered and returns the strings
          * to be rendered in the fee table.
          */
         let feeStr;
-        let amountOutStr;
+        let totalStr;
         if (Number(amountIn) !== 0) {
-          let amountOut = amountIn - fee;
+          let total = additiveFeesEnabled ? amountIn + fee : amountIn - fee;
           feeStr = fee.toFixed({{ asset.significant_decimals }});
-          amountOutStr = amountOut.toFixed({{ asset.significant_decimals }});
+          totalStr = total.toFixed({{ asset.significant_decimals }});
         } else {
           feeStr = "0";
-          amountOutStr = "0";
+          totalStr = additiveFeesEnabled ? amountIn.toFixed({{ asset.significant_decimals }}) : "0";
         }
-        return [feeStr, amountOutStr];
+        return [feeStr, totalStr];
       }
 
       function updateFeeTableHtml(feeStr, amountOutStr) {
@@ -238,8 +239,8 @@
             response => response.json()
           ).then(json => {
             if (!json.error) {
-              let [feeStr, amountOutStr] = calcFee(json.fee, amount);
-              updateFeeTableHtml(feeStr, amountOutStr);
+              let [feeStr, totalStr] = getFeeTableStrings(json.fee, amount);
+              updateFeeTableHtml(feeStr, totalStr);
             }
           });
         }, 500);
@@ -255,7 +256,7 @@
         let amountIn = Number(amountInput.value);
         if ("{{ use_fee_endpoint }}" !== "True") {
           let fee = fee_fixed + (amountIn * (fee_percent/100));
-          let [feeStr, amountOutStr] = calcFee(fee, amountIn);
+          let [feeStr, amountOutStr] = getFeeTableStrings(fee, amountIn);
           updateFeeTableHtml(feeStr, amountOutStr);
         } else {
           callFeeEndpoint(amountIn);


### PR DESCRIPTION
resolves #452

Gives SEP-24 anchors who use the built-in interactive flow the ability to add the fee amount to the amount the user should send the anchor, which enables the user to receive the amount specified in the `TransactionForm`.

Note that for SEP-6 and SEP-31, this setting has no effect and anchors must implement this functionality on their own.

cc @yuriescl 

Warning: because client applications could theoretically send an amount that differs from the amount initially specified, Polaris overwrites `Transaction.amount_in` with the amount actually received on Stellar. So anchors who wish to add fees to the amount clients send must ensure `Transaction.amount_fee` is the appropriate amount for `Transaction.amount_in` within `RailsIntegration.execute_outgoing_transaction`. If the fee is not correct for the updated `Transaction.amount_in` value, fees must be recalculated before delivering off-chain funds to the user.

I created an issue to add a `Transaction.amount_expected` column that will not be overwritten so that checking for this case is easier. #455 