### PR TITLE
paging_token blank=True

### DIFF
--- a/polaris/polaris/models.py
+++ b/polaris/polaris/models.py
@@ -363,7 +363,7 @@ class Transaction(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     """Unique, anchor-generated id for the deposit/withdrawal."""
 
-    paging_token = models.TextField(null=True)
+    paging_token = models.TextField(null=True, blank=True)
     """The token to be used as a cursor for querying before or after this transaction"""
 
     stellar_account = models.TextField(validators=[MinLengthValidator(1)])


### PR DESCRIPTION
Sometimes, in the Admin panel, we (Anchor) have to manually update a `Transaction`, but we get an error saying `paging_token` is required (but it doesn't contain a value yet). So we always have to put some arbitrary value there to be able to save.
This pull request makes the `paging_token` optional in forms.