### PR TITLE
Allow source and destination accounts that differ from authenticated account

### DIFF
--- a/polaris/polaris/management/commands/check_trustlines.py
+++ b/polaris/polaris/management/commands/check_trustlines.py
@@ -99,18 +99,16 @@ class Command(BaseCommand):
                     id__in=[t.id for t in still_process_transactions]
                 ).update(pending_execution_attempt=False)
                 break
-            if accounts.get(transaction.stellar_account):
-                account = accounts[transaction.stellar_account]
+            if accounts.get(transaction.to_address):
+                account = accounts[transaction.to_address]
             else:
                 try:
                     account = (
-                        server.accounts().account_id(transaction.stellar_account).call()
+                        server.accounts().account_id(transaction.to_address).call()
                     )
-                    accounts[transaction.stellar_account] = account
+                    accounts[transaction.to_address] = account
                 except BaseRequestError:
-                    logger.exception(
-                        f"Failed to load account {transaction.stellar_account}"
-                    )
+                    logger.exception(f"Failed to load account {transaction.to_address}")
                     transaction.pending_execution_attempt = False
                     transaction.save()
                     continue

--- a/polaris/polaris/management/commands/poll_pending_deposits.py
+++ b/polaris/polaris/management/commands/poll_pending_deposits.py
@@ -201,7 +201,7 @@ class PendingDeposits:
         """
         try:
             account, json_resp = get_account_obj(
-                Keypair.from_public_key(transaction.stellar_account)
+                Keypair.from_public_key(transaction.to_address)
             )
             return account, is_pending_trust(transaction, json_resp)
         except RuntimeError:  # account does not exist
@@ -230,7 +230,7 @@ class PendingDeposits:
                 or settings.HORIZON_SERVER.fetch_base_fee(),
             )
             transaction_envelope = builder.append_create_account_op(
-                destination=transaction.stellar_account,
+                destination=transaction.to_address,
                 starting_balance=settings.ACCOUNT_STARTING_BALANCE,
             ).build()
             transaction_envelope.sign(source_account_kp)
@@ -244,7 +244,7 @@ class PendingDeposits:
                 )
 
             account, _ = get_account_obj(
-                Keypair.from_public_key(transaction.stellar_account)
+                Keypair.from_public_key(transaction.to_address)
             )
             return account, True
         except BaseHorizonError as e:
@@ -355,7 +355,7 @@ class PendingDeposits:
             or settings.HORIZON_SERVER.fetch_base_fee(),
         )
         payment_op_kwargs = {
-            "destination": transaction.stellar_account,
+            "destination": transaction.to_address,
             "asset_code": transaction.asset.code,
             "asset_issuer": transaction.asset.issuer,
             "amount": str(payment_amount),
@@ -363,10 +363,10 @@ class PendingDeposits:
         }
         if transaction.claimable_balance_supported:
             _, json_resp = get_account_obj(
-                Keypair.from_public_key(transaction.stellar_account)
+                Keypair.from_public_key(transaction.to_address)
             )
             if is_pending_trust(transaction, json_resp):
-                claimant = Claimant(destination=transaction.stellar_account)
+                claimant = Claimant(destination=transaction.to_address)
                 asset = Asset(
                     code=transaction.asset.code, issuer=transaction.asset.issuer
                 )

--- a/polaris/polaris/tests/commands/test_poll_pending_deposits.py
+++ b/polaris/polaris/tests/commands/test_poll_pending_deposits.py
@@ -164,11 +164,13 @@ def test_get_ready_deposits_custom_fee_func_used(mock_rri):
 @patch(f"{test_module}.get_account_obj")
 def test_get_or_create_destination_account_exists(mock_get_account_obj):
     usd = Asset.objects.create(code="USD", issuer=Keypair.random().public_key)
+    destination = Keypair.random().public_key
     transaction = Transaction.objects.create(
         asset=usd,
         status=Transaction.STATUS.pending_user_transfer_start,
         kind=Transaction.KIND.deposit,
-        stellar_account=Keypair.random().public_key,
+        stellar_account=destination,
+        to_address=destination,
     )
     account_obj = Account(transaction.stellar_account, 1)
     mock_get_account_obj.return_value = (
@@ -183,15 +185,62 @@ def test_get_or_create_destination_account_exists(mock_get_account_obj):
 
 @pytest.mark.django_db
 @patch(f"{test_module}.get_account_obj")
-def test_get_or_create_destination_account_exists_pending_trust(mock_get_account_obj):
+def test_get_or_create_destination_account_exists_different_destination(
+    mock_get_account_obj,
+):
     usd = Asset.objects.create(code="USD", issuer=Keypair.random().public_key)
     transaction = Transaction.objects.create(
         asset=usd,
         status=Transaction.STATUS.pending_user_transfer_start,
         kind=Transaction.KIND.deposit,
         stellar_account=Keypair.random().public_key,
+        to_address=Keypair.random().public_key,
+    )
+    account_obj = Account(transaction.to_address, 1)
+    mock_get_account_obj.return_value = (
+        account_obj,
+        {"balances": [{"asset_code": "USD", "asset_issuer": usd.issuer}]},
+    )
+    assert PendingDeposits.get_or_create_destination_account(transaction) == (
+        account_obj,
+        False,
+    )
+
+
+@pytest.mark.django_db
+@patch(f"{test_module}.get_account_obj")
+def test_get_or_create_destination_account_exists_pending_trust(mock_get_account_obj):
+    usd = Asset.objects.create(code="USD", issuer=Keypair.random().public_key)
+    destination = Keypair.random().public_key
+    transaction = Transaction.objects.create(
+        asset=usd,
+        status=Transaction.STATUS.pending_user_transfer_start,
+        kind=Transaction.KIND.deposit,
+        stellar_account=destination,
+        to_address=destination,
     )
     account_obj = Account(transaction.stellar_account, 1)
+    mock_get_account_obj.return_value = (account_obj, {"balances": []})
+    assert PendingDeposits.get_or_create_destination_account(transaction) == (
+        account_obj,
+        True,
+    )
+
+
+@pytest.mark.django_db
+@patch(f"{test_module}.get_account_obj")
+def test_get_or_create_destination_account_exists_pending_trust_different_account(
+    mock_get_account_obj,
+):
+    usd = Asset.objects.create(code="USD", issuer=Keypair.random().public_key)
+    transaction = Transaction.objects.create(
+        asset=usd,
+        status=Transaction.STATUS.pending_user_transfer_start,
+        kind=Transaction.KIND.deposit,
+        stellar_account=Keypair.random().public_key,
+        to_address=Keypair.random().public_key,
+    )
+    account_obj = Account(transaction.to_address, 1)
     mock_get_account_obj.return_value = (account_obj, {"balances": []})
     assert PendingDeposits.get_or_create_destination_account(transaction) == (
         account_obj,
@@ -211,19 +260,21 @@ def test_get_or_create_destination_account_doesnt_exist(
         issuer=Keypair.random().public_key,
         distribution_seed=Keypair.random().secret,
     )
+    destination = Keypair.random().public_key
     transaction = Transaction.objects.create(
         asset=usd,
         status=Transaction.STATUS.pending_user_transfer_start,
         kind=Transaction.KIND.deposit,
-        stellar_account=Keypair.random().public_key,
+        stellar_account=destination,
+        to_address=destination,
     )
     mock_fetch_base_fee.return_value = 100
     mock_requires_multisig.return_value = False
-    stellar_account_obj = Account(transaction.stellar_account, 1)
+    stellar_account_obj = Account(transaction.to_address, 1)
     distribution_account_obj = Account(usd.distribution_account, 1)
 
     def mock_get_account_obj_func(kp: Keypair):
-        if kp.public_key == transaction.stellar_account:
+        if kp.public_key == transaction.to_address:
             if mock_submit_transaction.called:
                 return stellar_account_obj, {"balances": []}
             else:
@@ -243,10 +294,55 @@ def test_get_or_create_destination_account_doesnt_exist(
         assert envelope.transaction.source.public_key == usd.distribution_account
         assert len(envelope.transaction.operations) == 1
         assert isinstance(envelope.transaction.operations[0], CreateAccount)
-        assert (
-            envelope.transaction.operations[0].destination
-            == transaction.stellar_account
+        assert envelope.transaction.operations[0].destination == transaction.to_address
+
+
+@pytest.mark.django_db
+@patch(f"{test_module}.PendingDeposits.requires_multisig")
+@patch(f"{test_module}.settings.HORIZON_SERVER.fetch_base_fee")
+@patch(f"{test_module}.settings.HORIZON_SERVER.submit_transaction")
+def test_get_or_create_destination_account_doesnt_exist_different_destination(
+    mock_submit_transaction, mock_fetch_base_fee, mock_requires_multisig
+):
+    usd = Asset.objects.create(
+        code="USD",
+        issuer=Keypair.random().public_key,
+        distribution_seed=Keypair.random().secret,
+    )
+    transaction = Transaction.objects.create(
+        asset=usd,
+        status=Transaction.STATUS.pending_user_transfer_start,
+        kind=Transaction.KIND.deposit,
+        stellar_account=Keypair.random().public_key,
+        to_address=Keypair.random().public_key,
+    )
+    mock_fetch_base_fee.return_value = 100
+    mock_requires_multisig.return_value = False
+    stellar_account_obj = Account(transaction.to_address, 1)
+    distribution_account_obj = Account(usd.distribution_account, 1)
+
+    def mock_get_account_obj_func(kp: Keypair):
+        if kp.public_key == transaction.to_address:
+            if mock_submit_transaction.called:
+                return stellar_account_obj, {"balances": []}
+            else:
+                raise RuntimeError()
+        elif kp.public_key == usd.distribution_account:
+            return distribution_account_obj, None
+
+    with patch(f"{test_module}.get_account_obj", mock_get_account_obj_func):
+        assert PendingDeposits.get_or_create_destination_account(transaction) == (
+            stellar_account_obj,
+            True,
         )
+        mock_fetch_base_fee.assert_called()
+        mock_requires_multisig.assert_called()
+        mock_submit_transaction.assert_called_once()
+        envelope = mock_submit_transaction.mock_calls[0][1][0]
+        assert envelope.transaction.source.public_key == usd.distribution_account
+        assert len(envelope.transaction.operations) == 1
+        assert isinstance(envelope.transaction.operations[0], CreateAccount)
+        assert envelope.transaction.operations[0].destination == transaction.to_address
 
 
 @pytest.mark.django_db
@@ -265,20 +361,22 @@ def test_get_or_create_destination_account_doesnt_exist_requires_multisig(
         issuer=Keypair.random().public_key,
         distribution_seed=Keypair.random().secret,
     )
+    destination = Keypair.random().public_key
     transaction = Transaction.objects.create(
         asset=usd,
         status=Transaction.STATUS.pending_user_transfer_start,
         kind=Transaction.KIND.deposit,
-        stellar_account=Keypair.random().public_key,
+        stellar_account=destination,
+        to_address=destination,
         channel_seed=Keypair.random().secret,
     )
     mock_fetch_base_fee.return_value = 100
     mock_requires_multisig.return_value = True
-    stellar_account_obj = Account(transaction.stellar_account, 1)
+    stellar_account_obj = Account(transaction.to_address, 1)
     channel_account_obj = Account(transaction.channel_account, 1)
 
     def mock_get_account_obj_func(kp: Keypair):
-        if kp.public_key == transaction.stellar_account:
+        if kp.public_key == transaction.to_address:
             if mock_submit_transaction.called:
                 return stellar_account_obj, {"balances": []}
             else:
@@ -299,10 +397,61 @@ def test_get_or_create_destination_account_doesnt_exist_requires_multisig(
         assert envelope.transaction.source.public_key == transaction.channel_account
         assert len(envelope.transaction.operations) == 1
         assert isinstance(envelope.transaction.operations[0], CreateAccount)
-        assert (
-            envelope.transaction.operations[0].destination
-            == transaction.stellar_account
+        assert envelope.transaction.operations[0].destination == transaction.to_address
+
+
+@pytest.mark.django_db
+@patch(f"{test_module}.PendingDeposits.requires_multisig")
+@patch(f"{test_module}.settings.HORIZON_SERVER.fetch_base_fee")
+@patch(f"{test_module}.settings.HORIZON_SERVER.submit_transaction")
+@patch(f"{test_module}.rdi.create_channel_account")
+def test_get_or_create_destination_account_doesnt_exist_requires_multisig_different_destination(
+    mock_create_channel_account,
+    mock_submit_transaction,
+    mock_fetch_base_fee,
+    mock_requires_multisig,
+):
+    usd = Asset.objects.create(
+        code="USD",
+        issuer=Keypair.random().public_key,
+        distribution_seed=Keypair.random().secret,
+    )
+    transaction = Transaction.objects.create(
+        asset=usd,
+        status=Transaction.STATUS.pending_user_transfer_start,
+        kind=Transaction.KIND.deposit,
+        stellar_account=Keypair.random().public_key,
+        to_address=Keypair.random().public_key,
+        channel_seed=Keypair.random().secret,
+    )
+    mock_fetch_base_fee.return_value = 100
+    mock_requires_multisig.return_value = True
+    stellar_account_obj = Account(transaction.to_address, 1)
+    channel_account_obj = Account(transaction.channel_account, 1)
+
+    def mock_get_account_obj_func(kp: Keypair):
+        if kp.public_key == transaction.to_address:
+            if mock_submit_transaction.called:
+                return stellar_account_obj, {"balances": []}
+            else:
+                raise RuntimeError()
+        elif kp.public_key == transaction.channel_account:
+            return channel_account_obj, None
+
+    with patch(f"{test_module}.get_account_obj", mock_get_account_obj_func):
+        assert PendingDeposits.get_or_create_destination_account(transaction) == (
+            stellar_account_obj,
+            True,
         )
+        mock_fetch_base_fee.assert_called()
+        mock_requires_multisig.assert_called()
+        mock_create_channel_account.assert_not_called()
+        mock_submit_transaction.assert_called_once()
+        envelope = mock_submit_transaction.mock_calls[0][1][0]
+        assert envelope.transaction.source.public_key == transaction.channel_account
+        assert len(envelope.transaction.operations) == 1
+        assert isinstance(envelope.transaction.operations[0], CreateAccount)
+        assert envelope.transaction.operations[0].destination == transaction.to_address
 
 
 @pytest.mark.django_db
@@ -736,6 +885,7 @@ def test_create_transaction_envelope(mock_fetch_base_fee, mock_get_account_obj):
         status=Transaction.STATUS.pending_user_transfer_start,
         kind=Transaction.KIND.deposit,
         stellar_account=Keypair.random().public_key,
+        to_address=Keypair.random().public_key,
         amount_in=100,
         amount_fee=1,
         memo_type=Transaction.MEMO_TYPES.text,
@@ -759,7 +909,7 @@ def test_create_transaction_envelope(mock_fetch_base_fee, mock_get_account_obj):
     assert envelope.transaction.operations[0].asset, SdkAsset == SdkAsset(
         usd.code, usd.issuer
     )
-    assert envelope.transaction.operations[0].destination == transaction.stellar_account
+    assert envelope.transaction.operations[0].destination == transaction.to_address
 
 
 @pytest.mark.django_db
@@ -778,6 +928,7 @@ def test_create_transaction_envelope_claimable_balance_supported_has_trustline(
         status=Transaction.STATUS.pending_user_transfer_start,
         kind=Transaction.KIND.deposit,
         stellar_account=Keypair.random().public_key,
+        to_address=Keypair.random().public_key,
         amount_in=100,
         amount_fee=1,
         memo_type=Transaction.MEMO_TYPES.text,
@@ -793,7 +944,7 @@ def test_create_transaction_envelope_claimable_balance_supported_has_trustline(
     envelope = PendingDeposits.create_deposit_envelope(transaction, source_account)
 
     mock_get_account_obj.assert_called_once_with(
-        Keypair.from_public_key(transaction.stellar_account)
+        Keypair.from_public_key(transaction.to_address)
     )
     mock_fetch_base_fee.assert_called_once()
     assert isinstance(envelope, TransactionEnvelope)
@@ -808,7 +959,7 @@ def test_create_transaction_envelope_claimable_balance_supported_has_trustline(
     assert envelope.transaction.operations[0].asset, SdkAsset == SdkAsset(
         usd.code, usd.issuer
     )
-    assert envelope.transaction.operations[0].destination == transaction.stellar_account
+    assert envelope.transaction.operations[0].destination == transaction.to_address
 
 
 @pytest.mark.django_db
@@ -827,6 +978,7 @@ def test_create_transaction_envelope_claimable_balance_supported_no_trustline(
         status=Transaction.STATUS.pending_user_transfer_start,
         kind=Transaction.KIND.deposit,
         stellar_account=Keypair.random().public_key,
+        to_address=Keypair.random().public_key,
         amount_in=100,
         amount_fee=1,
         memo_type=Transaction.MEMO_TYPES.text,
@@ -839,7 +991,7 @@ def test_create_transaction_envelope_claimable_balance_supported_no_trustline(
     envelope = PendingDeposits.create_deposit_envelope(transaction, source_account)
 
     mock_get_account_obj.assert_called_once_with(
-        Keypair.from_public_key(transaction.stellar_account)
+        Keypair.from_public_key(transaction.to_address)
     )
     mock_fetch_base_fee.assert_called_once()
     assert isinstance(envelope, TransactionEnvelope)
@@ -858,7 +1010,7 @@ def test_create_transaction_envelope_claimable_balance_supported_no_trustline(
     assert isinstance(envelope.transaction.operations[0].claimants[0], Claimant)
     assert (
         envelope.transaction.operations[0].claimants[0].destination
-        == transaction.stellar_account
+        == transaction.to_address
     )
 
 

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -64,7 +64,7 @@ def test_deposit_success(client, acc1_usd_deposit_transaction_factory):
     assert t.from_address is None
     assert t.to_address == deposit.stellar_account
     assert t.memo is None
-    assert t.claimable_balance_support is False
+    assert t.claimable_balance_supported is False
 
 
 @pytest.mark.django_db

--- a/polaris/polaris/tests/sep24/test_deposit.py
+++ b/polaris/polaris/tests/sep24/test_deposit.py
@@ -49,7 +49,22 @@ def test_deposit_success(client, acc1_usd_deposit_transaction_factory):
         DEPOSIT_PATH, {"asset_code": "USD", "account": deposit.stellar_account},
     )
     content = json.loads(response.content)
+    t = Transaction.objects.first()
     assert content["type"] == "interactive_customer_info_needed"
+    assert t.amount_in is None
+    assert t.amount_out is None
+    assert t.amount_fee is None
+    assert t.kind == Transaction.KIND.deposit
+    assert t.protocol == Transaction.PROTOCOL.sep24
+    assert t.status == Transaction.STATUS.incomplete
+    assert t.stellar_account == "test source address"
+    assert t.asset == deposit.asset
+    assert t.started_at
+    assert t.completed_at is None
+    assert t.from_address is None
+    assert t.to_address == deposit.stellar_account
+    assert t.memo is None
+    assert t.claimable_balance_support is False
 
 
 @pytest.mark.django_db

--- a/polaris/polaris/tests/sep6/test_deposit.py
+++ b/polaris/polaris/tests/sep6/test_deposit.py
@@ -254,7 +254,7 @@ def test_deposit_transaction_created(
     assert t.memo_type == Transaction.MEMO_TYPES.id
     assert t.stellar_account == "test source address"
     assert not t.amount_in
-    assert t.to_address == "test source address"
+    assert t.to_address == deposit.stellar_account
     assert t.asset == deposit.asset
     assert t.kind == Transaction.KIND.deposit
     assert t.status == Transaction.STATUS.pending_user_transfer_start
@@ -437,6 +437,7 @@ def test_saved_transaction_on_failure_response(client, usd_asset_factory):
             "asset_code": asset.code,
             "type": "bank_account",
             "dest": "test bank account number",
+            "account": Keypair.random().public_key,
         },
     )
     assert response.status_code == 500


### PR DESCRIPTION
resolves #481 

Previous version of Polaris assumed that the account authenticated via SEP-10 was the destination account for the deposited funds. With the changes made in stellar/stellar-protocol#1041, SEP-24 and SEP-6 should allow the client to authenticate with one account and deposit funds to another.