### PR TITLE
SEP-6 & 24: Add 'features' object to `GET /info` responses

### DIFF
--- a/polaris/polaris/sep24/info.py
+++ b/polaris/polaris/sep24/info.py
@@ -44,7 +44,12 @@ def info(request):
     See: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#info
     """
 
-    info_data = {"deposit": {}, "withdraw": {}, "fee": {"enabled": True}}
+    info_data = {
+        "deposit": {},
+        "withdraw": {},
+        "fee": {"enabled": True},
+        "features": {"account_creation": True, "claimable_balances": True},
+    }
 
     for asset in Asset.objects.filter(sep24_enabled=True):
         info_data["deposit"][asset.code] = _get_asset_info(asset, "deposit")

--- a/polaris/polaris/sep6/info.py
+++ b/polaris/polaris/sep6/info.py
@@ -28,6 +28,7 @@ def info(request: Request) -> Response:
         "fee": {"enabled": True, "authentication_required": True},
         "transactions": {"enabled": True, "authentication_required": True},
         "transaction": {"enabled": True, "authentication_required": True},
+        "features": {"account_creation": True, "claimable_balances": True},
     }
     for asset in Asset.objects.filter(sep6_enabled=True):
         try:

--- a/polaris/polaris/tests/sep24/test_info.py
+++ b/polaris/polaris/tests/sep24/test_info.py
@@ -35,6 +35,10 @@ def _get_expected_response():
             },
             "fee": {
                 "enabled": true
+            },
+            "features": {
+                "account_creation": true,
+                "claimable_balances": true
             }
         }
     """

--- a/polaris/polaris/tests/sep6/test_info.py
+++ b/polaris/polaris/tests/sep6/test_info.py
@@ -117,6 +117,7 @@ def test_good_info_response(client, usd_asset_factory):
         "fee": {"enabled": True, "authentication_required": True},
         "transactions": {"enabled": True, "authentication_required": True},
         "transaction": {"enabled": True, "authentication_required": True},
+        "features": {"account_creation": True, "claimable_balances": True},
     }
 
 


### PR DESCRIPTION
SEP-6 and 24 were just recently updated to allow anchors to indicate whether they support specific features involved facilitating transactions. This PR updates Polaris to specify support for both features, account creation and claimable balances. 