### PR TITLE
Show asterisk for required fields

### DIFF
--- a/polaris/polaris/templates/polaris/deposit.html
+++ b/polaris/polaris/templates/polaris/deposit.html
@@ -24,7 +24,12 @@
       {% for field in form.visible_fields %}
         <div class="field">
           <label>
-            <div class="label">{{ field.label }}</div>
+            <div class="label">
+              {{ field.label }}
+              {% if field.field.required %}
+                <span class="required"> *</span>
+              {% endif %}
+            </div>
             <div class="control"> {{ field }} </div>
           </label>
 

--- a/polaris/polaris/templates/polaris/withdraw.html
+++ b/polaris/polaris/templates/polaris/withdraw.html
@@ -23,7 +23,12 @@
 
             {% for field in form.visible_fields %}
             <div class="field">
-                <label class="label"> {{ field.label }}</label>
+                <label class="label">
+                  {{ field.label }}
+                  {% if field.field.required %}
+                    <span class="required"> *</span>
+                  {% endif %}
+                </div>
                 <div class="control"> {{ field }} </div>
 
                 {% if field.errors %}


### PR DESCRIPTION
This is a minor UI improvement. It adds an asterisk after the field label if the field is required. It helps the user to know which fields are required in a given form.

I'm not very familiar with SCSS and compiling it to CSS, so you'd need to add the styling for the `required` class.
I suggest something similar to this:
```
.field label span.required {
    color: red;
    font-weight: bold;
}
```