### PR TITLE
updating log statements for process_pending_deposits

### DIFF
--- a/polaris/polaris/management/commands/process_pending_deposits.py
+++ b/polaris/polaris/management/commands/process_pending_deposits.py
@@ -204,12 +204,11 @@ class PendingDeposits:
             In this case, the transaction is submitted to the Stellar Network and
             updated as complete after success.
         """
-        logger.debug(f"processing transaction {transaction.id}")
+        logger.info(f"processing transaction {transaction.id}")
         if await cls.requires_trustline(transaction, server, locks):
-            logger.debug(f"transaction {transaction.id} requires trustline")
             return
 
-        logger.debug(f"transaction {transaction.id} is not pending trust")
+        logger.info(f"transaction {transaction.id} has the appropriate trustline")
         try:
             requires_multisig = await cls.requires_multisig(transaction)
         except NotFoundError:
@@ -229,6 +228,7 @@ class PendingDeposits:
             await maybe_make_callback_async(transaction)
             return
         if requires_multisig:
+            logger.info(f"transaction {transaction.id} requires multiple signatures")
             await cls.save_as_pending_signatures(transaction, server)
             return
         logger.debug(f"transaction {transaction.id} does not require multisig")
@@ -421,9 +421,6 @@ class PendingDeposits:
                     )
                     raise RuntimeError("the distribution account does not exist")
                 if requires_multisig:
-                    logger.debug(
-                        f"creating channel account for transaction {transaction.id}"
-                    )
                     source_account_kp = await sync_to_async(cls.get_channel_keypair)(
                         transaction
                     )
@@ -489,6 +486,9 @@ class PendingDeposits:
         transaction is scheduled for processing. If not, the transaction is
         updated to no longer be pending an execution attempt.
         """
+        logger.info(
+            f"checking for the appropriate trustline for transaction {transaction.id}"
+        )
         try:
             _, account = await get_account_obj_async(
                 Keypair.from_public_key(transaction.to_address), server
@@ -531,9 +531,9 @@ class PendingDeposits:
                 f"{' or '.join(valid_statuses)}."
             )
 
+        logger.info(f"initiating Stellar deposit for {transaction.id}")
         transaction.status = Transaction.STATUS.pending_anchor
         await sync_to_async(transaction.save)()
-        logger.debug(f"initiating Stellar deposit for {transaction.id}")
         await maybe_make_callback_async(transaction)
 
         envelope = None
@@ -566,7 +566,9 @@ class PendingDeposits:
 
             transaction.status = Transaction.STATUS.pending_stellar
             await sync_to_async(transaction.save)()
-            logger.debug(f"transaction {transaction.id} now pending_stellar")
+            logger.info(
+                f"updating transaction {transaction.id} to pending_stellar status"
+            )
             await maybe_make_callback_async(transaction)
 
             try:
@@ -713,7 +715,7 @@ class PendingDeposits:
             return True
 
         if pending_trust and not transaction.claimable_balance_supported:
-            logger.debug(
+            logger.info(
                 f"destination account is pending_trust for transaction {transaction.id}"
             )
             transaction.status = Transaction.STATUS.pending_trust
@@ -762,6 +764,9 @@ class PendingDeposits:
     @staticmethod
     def get_channel_keypair(transaction) -> Keypair:
         if not transaction.channel_account:
+            logger.info(
+                f"calling create_channel_account() for transaction {transaction.id}"
+            )
             rdi.create_channel_account(transaction=transaction)
         if not transaction.channel_seed:
             asset = transaction.asset


### PR DESCRIPTION
I added a bunch of debug log statements while developing the async functionality in `process_pending_deposits`. Some of these log statements should be upgraded to "info" level.