### PR TITLE
raise NotImplementedErrors for base integration functions

### DIFF
--- a/example/server/integrations.py
+++ b/example/server/integrations.py
@@ -653,7 +653,7 @@ class MyCustomerIntegration(CustomerIntegration):
 
         if (
             user.email != params.get("email_address")
-            and PolarisUser.objects.filter(email=params["email_address"]).exists()
+            and PolarisUser.objects.filter(email=params.get("email_address")).exists()
         ):
             raise ValueError("email_address is taken")
 

--- a/polaris/polaris/integrations/customers.py
+++ b/polaris/polaris/integrations/customers.py
@@ -25,7 +25,7 @@ class CustomerIntegration:
         :param request: a ``rest_framework.request.Request`` instance
         :param account: the stellar account for the url to be returned
         """
-        pass
+        raise NotImplementedError()
 
     def get(
         self,
@@ -54,7 +54,7 @@ class CustomerIntegration:
         :param request: a ``rest_framework.request.Request`` instance
         :param params: request parameters as described in SEP-12
         """
-        pass
+        raise NotImplementedError()
 
     def put(
         self,
@@ -99,7 +99,7 @@ class CustomerIntegration:
         :param params: request parameters as described in SEP-12_
         :raises: ValueError or ObjectDoesNotExist
         """
-        pass
+        raise NotImplementedError()
 
     def delete(
         self,
@@ -122,7 +122,7 @@ class CustomerIntegration:
         :param memo: the optional memo used to create the customer
         :param memo_type: the optional type of the memo used to create to the customer
         """
-        pass
+        raise NotImplementedError()
 
     def callback(
         self,

--- a/polaris/polaris/integrations/info.py
+++ b/polaris/polaris/integrations/info.py
@@ -61,7 +61,7 @@ def default_info_func(
     :param lang: the language code the client requested for the `description`
         values in the response
     """
-    return {}
+    raise NotImplementedError()
 
 
 registered_info_func = default_info_func

--- a/polaris/polaris/integrations/rails.py
+++ b/polaris/polaris/integrations/rails.py
@@ -25,7 +25,7 @@ class RailsIntegration:
 
         :param transactions: a ``QuerySet`` of ``Transaction`` objects
         """
-        pass
+        raise NotImplementedError()
 
     def execute_outgoing_transaction(
         self, transaction: Transaction, *args: List, **kwargs: Dict
@@ -80,7 +80,7 @@ class RailsIntegration:
         :param transaction: the ``Transaction`` object associated with the payment
             this function should make
         """
-        pass
+        raise NotImplementedError()
 
     def poll_pending_deposits(
         self, pending_deposits: QuerySet, *args: List, **kwargs: Dict
@@ -164,7 +164,7 @@ class RailsIntegration:
         :return: a list of ``Transaction`` objects which correspond to
             successful user deposits to the anchor's account.
         """
-        pass
+        raise NotImplementedError()
 
 
 registered_rails_integration = RailsIntegration()

--- a/polaris/polaris/integrations/sep31.py
+++ b/polaris/polaris/integrations/sep31.py
@@ -72,7 +72,7 @@ class SEP31ReceiverIntegration:
         :param asset: the ``Asset`` object for the field values returned
         :param lang: the ISO 639-1 language code of the user
         """
-        pass
+        raise NotImplementedError()
 
     def process_post_request(
         self,
@@ -156,7 +156,7 @@ class SEP31ReceiverIntegration:
         :param params: The parameters included in the `/transaction` request
         :param transaction: the ``Transaction`` object representing the transaction being processed
         """
-        pass
+        raise NotImplementedError()
 
     def process_patch_request(
         self,
@@ -191,7 +191,7 @@ class SEP31ReceiverIntegration:
         :param params: the request body of the `PATCH /transaction` request
         :param transaction: the ``Transaction`` object that should be updated
         """
-        pass
+        raise NotImplementedError()
 
     def valid_sending_anchor(
         self,
@@ -210,7 +210,7 @@ class SEP31ReceiverIntegration:
         :param request: the ``rest_framework.request.Request`` instance
         :param public_key: the public key of the sending anchor's stellar account
         """
-        pass
+        raise NotImplementedError()
 
 
 registered_sep31_receiver_integration = SEP31ReceiverIntegration()

--- a/polaris/polaris/integrations/transactions.py
+++ b/polaris/polaris/integrations/transactions.py
@@ -38,7 +38,7 @@ class DepositIntegration:
         :param transaction: a ``Transaction`` that was executed on the
             Stellar network
         """
-        pass
+        raise NotImplementedError()
 
     def form_for_transaction(
         self,
@@ -185,7 +185,7 @@ class DepositIntegration:
         :param form: the form to be rendered in the template
         :param transaction: the transaction being processed
         """
-        pass
+        raise NotImplementedError()
 
     def after_form_validation(
         self,
@@ -227,7 +227,7 @@ class DepositIntegration:
         :param form: the completed ``forms.Form`` submitted by the user
         :param transaction: the ``Transaction`` database object
         """
-        pass
+        raise NotImplementedError()
 
     def interactive_url(
         self,
@@ -247,7 +247,7 @@ class DepositIntegration:
         :return: a URL to be used as the entry point for the interactive
             deposit flow
         """
-        pass
+        raise NotImplementedError()
 
     def save_sep9_fields(
         self,
@@ -293,7 +293,7 @@ class DepositIntegration:
         the exception in the response along with 400 HTTP status. The error message should be
         in the language specified by `language_code` if possible.
         """
-        pass
+        raise NotImplementedError()
 
     def process_sep6_request(
         self,
@@ -411,7 +411,7 @@ class DepositIntegration:
         :param transaction: An object representing the transaction that requires a channel
             account as it's source.
         """
-        pass
+        raise NotImplementedError()
 
     def patch_transaction(
         self,
@@ -524,7 +524,7 @@ class WithdrawalIntegration:
         :param form: the form to be rendered in the template
         :param transaction: the transaction being processed
         """
-        pass
+        raise NotImplementedError()
 
     def after_form_validation(
         self,
@@ -542,7 +542,7 @@ class WithdrawalIntegration:
         :param form: the completed ``forms.Form`` submitted by the user
         :param transaction: the ``Transaction`` database object
         """
-        pass
+        raise NotImplementedError()
 
     def interactive_url(
         self,
@@ -560,7 +560,7 @@ class WithdrawalIntegration:
         :return: a URL to be used as the entry point for the interactive
             withdraw flow
         """
-        pass
+        raise NotImplementedError()
 
     def save_sep9_fields(
         self,
@@ -576,7 +576,7 @@ class WithdrawalIntegration:
         """
         Same as ``DepositIntegration.save_sep9_fields``
         """
-        pass
+        raise NotImplementedError()
 
     def process_sep6_request(
         self,

--- a/polaris/polaris/management/commands/execute_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/execute_outgoing_transactions.py
@@ -111,6 +111,12 @@ class Command(BaseCommand):
             logger.info(f"Calling execute_outgoing_transaction() for {transaction.id}")
             try:
                 rri.execute_outgoing_transaction(transaction)
+            except NotImplementedError:
+                logger.error(
+                    "RailsIntegration.execute_outgoing_transaction() is not implemented"
+                )
+                module.TERMINATE = True
+                break
             except Exception:
                 transaction.pending_execution_attempt = False
                 transaction.save()

--- a/polaris/polaris/management/commands/poll_outgoing_transactions.py
+++ b/polaris/polaris/management/commands/poll_outgoing_transactions.py
@@ -70,6 +70,10 @@ class Command(BaseCommand):
         )
         try:
             complete_transactions = rri.poll_outgoing_transactions(transactions)
+        except NotImplementedError:
+            module = sys.modules[__name__]
+            module.TERMINATE = True
+            return
         except Exception:
             logger.exception("An exception was raised by poll_pending_transfers()")
             return

--- a/polaris/polaris/management/commands/process_pending_deposits.py
+++ b/polaris/polaris/management/commands/process_pending_deposits.py
@@ -739,8 +739,8 @@ class PendingDeposits:
 
     @classmethod
     async def save_as_pending_signatures(cls, transaction, server):
-        channel_kp = await sync_to_async(cls.get_channel_keypair)(transaction)
         try:
+            channel_kp = await sync_to_async(cls.get_channel_keypair)(transaction)
             channel_account, _ = await get_account_obj_async(channel_kp, server)
         except (RuntimeError, ConnectionError) as e:
             transaction.status = Transaction.STATUS.error

--- a/polaris/polaris/sep6/utils.py
+++ b/polaris/polaris/sep6/utils.py
@@ -7,6 +7,7 @@ from polaris.utils import SEP_9_FIELDS
 from polaris.integrations import registered_customer_integration as rci
 from polaris.models import Transaction
 from polaris.sep10.token import SEP10Token
+from polaris import settings
 
 
 logger = getLogger(__name__)
@@ -51,10 +52,10 @@ def validate_403_response(
             logger.error("Invalid 'status' returned from process_sep6_request()")
             raise ValueError()
         response["status"] = integration_response["status"]
-        more_info_url = rci.more_info_url(
-            token=token, request=request, account=transaction.stellar_account
-        )
-        if more_info_url:
+        if settings.SEP6_USE_MORE_INFO_URL:
+            more_info_url = rci.more_info_url(
+                token=token, request=request, account=transaction.stellar_account
+            )
             response["more_info_url"] = more_info_url
 
     else:

--- a/polaris/polaris/shared/endpoints.py
+++ b/polaris/polaris/shared/endpoints.py
@@ -49,19 +49,22 @@ def more_info(request: Request, sep6: bool = False) -> Response:
         "asset_code": request_transaction.asset.code,
         "asset": request_transaction.asset,
     }
-    if request_transaction.kind == Transaction.KIND.deposit:
-        content = rdi.content_for_template(
-            request=request,
-            template=Template.MORE_INFO,
-            transaction=request_transaction,
-        )
+    try:
+        if request_transaction.kind == Transaction.KIND.deposit:
+            content = rdi.content_for_template(
+                request=request,
+                template=Template.MORE_INFO,
+                transaction=request_transaction,
+            )
+        else:
+            content = rwi.content_for_template(
+                request=request,
+                template=Template.MORE_INFO,
+                transaction=request_transaction,
+            )
+    except NotImplementedError:
+        pass
     else:
-        content = rwi.content_for_template(
-            request=request,
-            template=Template.MORE_INFO,
-            transaction=request_transaction,
-        )
-    if content:
         context.update(content)
 
     # more_info.html will update the 'callback' parameter value to 'success' after

--- a/polaris/polaris/tests/sep12/test_customer.py
+++ b/polaris/polaris/tests/sep12/test_customer.py
@@ -542,9 +542,11 @@ def test_get_valid_error_value(client):
 
 
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)
-def test_delete_success(client):
+@patch("polaris.sep12.customer.rci.delete")
+def test_delete_success(mock_delete, client):
     response = client.delete("/".join([endpoint, "test source address"]))
     assert response.status_code == 200
+    mock_delete.asset_called_once()
 
 
 @patch("polaris.sep10.utils.check_auth", mock_check_auth_success)


### PR DESCRIPTION
Polaris' base class integration functions previously had an inconsistent behavior: some functions raised `NotImplementedError` when called and others returned `None`. This PR makes this behavior consistent; raising `NotImpelmentedError` for all unimplemented integration functions. 

It also adjusts the Polaris code that calls these functions to expect the error and handle it appropriately. Integrations that are required to fulfill the request made are not handled and will subsequently cause a 500 error on the server. Integrations that are optional have their exceptions caught and handled.