### PR TITLE
include scripts directory in manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ include .env.example
 include polaris/polaris/static/polaris/base.css
 include polaris/polaris/static/polaris/company-icon.svg
 include polaris/polaris/static/polaris/chevron-down.svg
+recursive-include polaris/polaris/static/polaris/scripts *
 recursive-include polaris/polaris/templates *
 recursive-include polaris/polaris/locale *


### PR DESCRIPTION
resolves #513 

The packaged version of Polaris 2.0.0 doesn't include the `static/polaris/scripts` directory, which is required for SEP-24 deployments. This requires specifying the directory in MANIFEST.in file which is what determines which static files are included when packaging.

I'll have to remove the 2.0.0 release when we publish 2.0.1.

cc @yuriescl 