### PR TITLE
SEP-31: pass request object to info integration for POST /transactions requests

### DIFF
--- a/polaris/polaris/management/commands/process_pending_deposits.py
+++ b/polaris/polaris/management/commands/process_pending_deposits.py
@@ -619,7 +619,9 @@ class PendingDeposits:
         if success:
             await sync_to_async(transaction.refresh_from_db)()
             try:
-                await sync_to_async(rdi.after_deposit)(transaction)
+                await sync_to_async(rdi.after_deposit)(transaction=transaction)
+            except NotImplementedError:
+                pass
             except Exception:
                 logger.exception("after_deposit() threw an unexpected exception")
 

--- a/polaris/polaris/sep31/transactions.py
+++ b/polaris/polaris/sep31/transactions.py
@@ -118,7 +118,7 @@ class TransactionsAPIView(APIView):
 
         # validate fields separately since error responses need different format
         missing_fields = validate_post_fields(
-            params.get("fields"), params.get("asset"), params.get("lang")
+            request, params.get("fields"), params.get("asset"), params.get("lang")
         )
         if missing_fields:
             return Response(
@@ -206,12 +206,12 @@ def validate_post_request(request: Request) -> Dict:
 
 
 def validate_post_fields(
-    passed_fields: Dict, asset: Asset, lang: Optional[str]
+    request: Request, passed_fields: Dict, asset: Asset, lang: Optional[str]
 ) -> Dict:
     missing_fields = defaultdict(dict)
-    expected_fields = registered_sep31_receiver_integration.info(asset, lang).get(
-        "fields", {}
-    )
+    expected_fields = registered_sep31_receiver_integration.info(
+        request=request, asset=asset, lang=lang
+    ).get("fields", {})
     if "transaction" not in expected_fields:
         return {}
     elif "transaction" not in passed_fields:

--- a/polaris/polaris/tests/commands/test_poll_pending_deposits.py
+++ b/polaris/polaris/tests/commands/test_poll_pending_deposits.py
@@ -945,7 +945,7 @@ async def test_handle_submit_success():
 
                 mock_submit.assert_called_once_with(transaction, server, {})
                 transaction.refresh_from_db.assert_called_once()
-                mock_rdi.after_deposit.assert_called_once_with(transaction)
+                mock_rdi.after_deposit.assert_called_once_with(transaction=transaction)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -1003,7 +1003,9 @@ async def test_handle_submit_success_after_deposit_exception():
 
                     mock_submit.assert_called_once_with(transaction, server, {})
                     transaction.refresh_from_db.assert_called_once()
-                    mock_rdi.after_deposit.assert_called_once_with(transaction)
+                    mock_rdi.after_deposit.assert_called_once_with(
+                        transaction=transaction
+                    )
                     mock_logger.exception.assert_called_once()
 
 

--- a/polaris/polaris/tests/sep31/test_send.py
+++ b/polaris/polaris/tests/sep31/test_send.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from stellar_sdk import Keypair
+from rest_framework.request import Request
 
 from polaris.tests.helpers import mock_check_auth_success
 from polaris.models import Transaction
@@ -52,6 +53,11 @@ def test_successful_send(client, usd_asset_factory):
     )
     assert body["stellar_memo_type"] == Transaction.MEMO_TYPES.hash
     assert body["stellar_account_id"] == asset.distribution_account
+    kwargs = success_send_integration.info.call_args_list[-1][1]
+    assert isinstance(kwargs.get("request"), Request)
+    assert kwargs.get("asset").code == asset.code
+    assert kwargs.get("asset").issuer == asset.issuer
+    assert kwargs.get("lang") is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Polaris calls `SEP31ReceiverIntegration.info()` in `POST /transactions` requests so it can validate that the required transaction fields were passed. Starting in v2, Polaris added `request` arguments to all integration functions, but this argument is not passed to the `.info()` call.

This bug didn't result in failing tests because `.info()`'s function signature had 1 positional argument and 1 optional keyword argument. In 2.0, it was updated to have 2 positional arguments and 1 optional keyword. In both v1 and v2, Polaris called the function like so:

```python
expected_fields = registered_sep31_receiver_integration.info(asset, lang).get(
    "fields", {}
)
```

Which did not raise any errors when run and no tests evaluated the types of the parameters passed to the function.