### PR TITLE
SEP-31: don't require 'transaction' key in 'fields' passed

### DIFF
--- a/polaris/polaris/sep31/transactions.py
+++ b/polaris/polaris/sep31/transactions.py
@@ -214,13 +214,10 @@ def validate_post_fields(
     ).get("fields", {})
     if "transaction" not in expected_fields:
         return {}
-    elif "transaction" not in passed_fields:
-        missing_fields["transaction"] = expected_fields["transaction"]
-        return missing_fields
     for field, info in expected_fields["transaction"].items():
         if info.get("optional"):
             continue
-        elif field not in passed_fields["transaction"]:
+        elif field not in passed_fields.get("transaction", {}):
             missing_fields["transaction"][field] = info
     return dict(missing_fields)
 


### PR DESCRIPTION
SEP-31 requires that `POST /transactions` requests contain a `"fields": {"transaction": {}}` structure, but Polaris can be forgiving if the anchor doesn't require any transaction fields and the wallet sends `"fields": {}`.

Previously, Polaris would have returned 400 if the inner `"transaction"` was not present in the request.