### PR TITLE
SEP-24: fix form validation and retrieval order

### DIFF
--- a/polaris/polaris/sep24/deposit.py
+++ b/polaris/polaris/sep24/deposit.py
@@ -139,13 +139,13 @@ def post_interactive_deposit(request: Request) -> Response:
             )
             transaction.save()
 
-        next_form = rdi.form_for_transaction(request=request, transaction=transaction)
         try:
             rdi.after_form_validation(
                 request=request, form=form, transaction=transaction
             )
         except NotImplementedError:
             pass
+        next_form = rdi.form_for_transaction(request=request, transaction=transaction)
         try:
             next_content = rdi.content_for_template(
                 request=request,

--- a/polaris/polaris/sep24/withdraw.py
+++ b/polaris/polaris/sep24/withdraw.py
@@ -136,13 +136,13 @@ def post_interactive_withdraw(request: Request) -> Response:
             )
             transaction.save()
 
-        next_form = rwi.form_for_transaction(request=request, transaction=transaction)
         try:
             rwi.after_form_validation(
                 request=request, form=form, transaction=transaction
             )
         except NotImplementedError:
             pass
+        next_form = rwi.form_for_transaction(request=request, transaction=transaction)
         try:
             next_content = rwi.content_for_template(
                 request=request,


### PR DESCRIPTION
The changes to 2.0 involved adjusting how the SEP-24 form integration functions were called, and the order in which they are called in 2.0+ is incorrect.

Polaris must call `after_form_validation()` to validate the form data posted by the client prior to calling `form_for_transaction()` to fetch the next form to serve. However in Polaris 2.0+ this was not the case. The result is that state tracking logic in `after_form_validation()` wouldn't be executed prior to retrieving the next form, causing the wrong form to be displayed or an unexpected exception to occur.

We'll need to release a patch version for this issue.