### PR TITLE
SEP-24: deserialize transaction json before sending via callback

### DIFF
--- a/polaris/polaris/static/polaris/scripts/callback.js
+++ b/polaris/polaris/static/polaris/scripts/callback.js
@@ -50,7 +50,7 @@ function callback({
       return;
     }
 
-    targetWindow.postMessage(txJSON, "*");
+    targetWindow.postMessage(JSON.parse(txJSON), "*");
     if (onChange) {
       updateURLForOnChangeStatus();
     } else {


### PR DESCRIPTION
[Window.postmessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#syntax) accepts both objects and strings, but on the documentation it notes that serialization of data is unnecessary. We'll take this advice and pass a plain javascript object to the `postMessage()` call.