### PR TITLE
Add asset identification format property to asset models

### DIFF
--- a/example/server/integrations/deposit.py
+++ b/example/server/integrations/deposit.py
@@ -45,7 +45,7 @@ class MyDepositIntegration(DepositIntegration):
             else:
                 return SelectAssetForm()
         elif not transaction.amount_in:  # the user hasn't entered the amount to provide
-            if transaction.fee_asset == asset_id_format(transaction.asset):
+            if transaction.fee_asset == transaction.asset.asset_identification_format:
                 if post_data:
                     return TransactionForm(transaction, post_data)
                 else:
@@ -203,8 +203,8 @@ class MyDepositIntegration(DepositIntegration):
                 account_memo=transaction.account_memo,
                 muxed_account=transaction.muxed_account,
                 price=price,
-                sell_asset=offchain_asset_extra.offchain_asset.asset,
-                buy_asset=asset_id_format(transaction.asset),
+                sell_asset=offchain_asset_extra.offchain_asset.asset_identification_format,
+                buy_asset=transaction.asset.asset_identification_format,
                 sell_amount=transaction.amount_in,
                 buy_amount=round(
                     transaction.amount_in / price,
@@ -286,7 +286,7 @@ class MyDepositIntegration(DepositIntegration):
                 offchain_asset=params["source_asset"]
             )
             transaction.amount_in = params["amount"]
-            transaction.fee_asset = asset_id_format(params["source_asset"])
+            transaction.fee_asset = params["source_asset"].asset_identification_format
             if transaction.quote.type == Quote.TYPE.firm:
                 transaction.amount_fee = round(
                     offchain_asset_extra.fee_fixed

--- a/example/server/integrations/sep31.py
+++ b/example/server/integrations/sep31.py
@@ -84,7 +84,7 @@ class MySEP31ReceiverIntegration(SEP31ReceiverIntegration):
             ),
             transaction.asset.significant_decimals,
         )
-        transaction.fee_asset = asset_id_format(params["asset"])
+        transaction.fee_asset = params["asset"].asset_identification_format
         if not transaction.quote:
             transaction.amount_out = round(
                 transaction.amount_in - transaction.amount_fee,

--- a/example/server/integrations/withdraw.py
+++ b/example/server/integrations/withdraw.py
@@ -165,7 +165,7 @@ class MyWithdrawalIntegration(WithdrawalIntegration):
             )
         if isinstance(form, SelectAssetForm):
             # users will be charged fees in the units of the asset on Stellar
-            transaction.fee_asset = asset_id_format(transaction.asset)
+            transaction.fee_asset = transaction.asset.asset_identification_format
             if form.cleaned_data["asset"] == "iso4217:USD":
                 scheme, identifier = form.cleaned_data["asset"].split(":")
                 offchain_asset = OffChainAsset.objects.get(
@@ -181,8 +181,8 @@ class MyWithdrawalIntegration(WithdrawalIntegration):
                     account_memo=transaction.account_memo,
                     muxed_account=transaction.muxed_account,
                     price=price,
-                    sell_asset=asset_id_format(transaction.asset),
-                    buy_asset=offchain_asset.asset,
+                    sell_asset=transaction.asset.asset_identification_format,
+                    buy_asset=offchain_asset.asset_identification_format,
                     sell_amount=transaction.amount_in,
                     buy_amount=round(
                         transaction.amount_in / price,
@@ -266,7 +266,9 @@ class MyWithdrawalIntegration(WithdrawalIntegration):
                 }
             )
             if params.get("source_asset"):
-                transaction.fee_asset = asset_id_format(params["source_asset"])
+                transaction.fee_asset = params[
+                    "source_asset"
+                ].asset_identification_format
                 if transaction.quote.type == Quote.TYPE.firm:
                     transaction.amount_out = round(
                         transaction.quote.buy_amount

--- a/example/server/models.py
+++ b/example/server/models.py
@@ -83,4 +83,4 @@ class OffChainAssetExtra(models.Model):
     objects = models.Manager()
 
     def __str__(self):
-        return f"OffChainAsset: {self.offchain_asset.asset}"
+        return f"OffChainAsset: {self.offchain_asset.asset_identification_format}"

--- a/polaris/polaris/models.py
+++ b/polaris/polaris/models.py
@@ -241,6 +241,13 @@ class Asset(TimeStampedModel):
             return None
         return Keypair.from_secret(str(self.distribution_seed)).public_key
 
+    @property
+    def asset_identification_format(self):
+        """
+        SEP-38 asset identification format
+        """
+        return f"stellar:{self.code}:{self.issuer}"
+
     def get_distribution_account_data(self, refresh=False):
         if refresh or self.distribution_account not in ASSET_DISTRIBUTION_ACCOUNT_MAP:
             account_json = (
@@ -850,7 +857,7 @@ class OffChainAsset(models.Model):
     objects = models.Manager()
 
     @property
-    def asset(self):
+    def asset_identification_format(self):
         return f"{self.scheme}:{self.identifier}"
 
 

--- a/polaris/polaris/sep38/prices.py
+++ b/polaris/polaris/sep38/prices.py
@@ -13,7 +13,6 @@ from polaris.integrations import registered_quote_integration as rqi
 from polaris.utils import render_error_response, getLogger
 from polaris.models import DeliveryMethod
 from polaris.sep38.utils import (
-    asset_id_format,
     get_buy_assets,
     get_sell_asset,
     get_buy_asset,
@@ -96,7 +95,7 @@ def get_prices(token: SEP10Token, request: Request) -> Response:
         price = prices[idx]
         buy_assets.append(
             {
-                "asset": asset_id_format(buy_asset),
+                "asset": buy_asset.asset_identification_format,
                 "price": str(
                     round(price, request_data["sell_asset"].significant_decimals)
                 ),

--- a/polaris/polaris/sep38/quote.py
+++ b/polaris/polaris/sep38/quote.py
@@ -20,7 +20,6 @@ from polaris.sep38.serializers import QuoteSerializer
 from polaris.sep38.utils import (
     get_buy_asset,
     get_sell_asset,
-    asset_id_format,
     find_delivery_method,
 )
 from polaris.utils import getLogger
@@ -184,8 +183,8 @@ def make_quote(
         account_memo=token.memo,
         muxed_account=token.muxed_account,
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(sell_asset),
-        buy_asset=asset_id_format(buy_asset),
+        sell_asset=sell_asset.asset_identification_format,
+        buy_asset=buy_asset.asset_identification_format,
         sell_amount=sell_amount,
         buy_amount=buy_amount,
         buy_delivery_method=buy_delivery_method,

--- a/polaris/polaris/sep38/serializers.py
+++ b/polaris/polaris/sep38/serializers.py
@@ -81,7 +81,7 @@ class OffChainAssetSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_asset(instance):
-        return instance.asset
+        return instance.asset_identification_format
 
     @staticmethod
     def get_country_codes(instance):

--- a/polaris/polaris/sep38/utils.py
+++ b/polaris/polaris/sep38/utils.py
@@ -7,13 +7,6 @@ from django.db.models import Q
 from polaris.models import OffChainAsset, Asset, ExchangePair, DeliveryMethod
 
 
-def asset_id_format(asset: Union[Asset, OffChainAsset]) -> str:
-    if isinstance(asset, Asset):
-        return f"stellar:{asset.code}:{asset.issuer}"
-    else:
-        return asset.asset
-
-
 def asset_id_to_kwargs(asset_id: str) -> dict:
     if asset_id.startswith("stellar"):
         _, code, issuer = asset_id.split(":")
@@ -32,7 +25,7 @@ def get_buy_assets(
     buy_delivery_method: Optional[str],
     country_code: Optional[str],
 ) -> List[Union[Asset, OffChainAsset]]:
-    asset_str = asset_id_format(sell_asset)
+    asset_str = sell_asset.asset_identification_format
     pairs = ExchangePair.objects.filter(sell_asset=asset_str).all()
     if not pairs:
         return []
@@ -116,7 +109,7 @@ def get_buy_asset(
                 )
             )
     if not ExchangePair.objects.filter(
-        sell_asset=asset_id_format(sell_asset), buy_asset=buy_asset_str
+        sell_asset=sell_asset.asset_identification_format, buy_asset=buy_asset_str
     ).exists():
         raise ValueError(gettext("unsupported asset pair"))
     return buy_asset

--- a/polaris/polaris/tests/sep31/test_send.py
+++ b/polaris/polaris/tests/sep31/test_send.py
@@ -9,7 +9,6 @@ from rest_framework.request import Request
 from polaris.tests.helpers import mock_check_auth_success
 from polaris.models import Transaction, OffChainAsset, ExchangePair, Quote
 from polaris.sep31.transactions import process_post_response
-from polaris.sep38.utils import asset_id_format
 
 
 transaction_endpoint = "/sep31/transactions"
@@ -82,14 +81,15 @@ def test_successful_send_indicative_quote(client, usd_asset_factory):
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     response = client.post(
         transaction_endpoint,
         {
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -123,8 +123,8 @@ def test_successful_send_indicative_quote(client, usd_asset_factory):
     assert isinstance(transaction.quote, Quote)
     assert transaction.quote.id
     assert transaction.quote.type == Quote.TYPE.indicative
-    assert transaction.quote.sell_asset == asset_id_format(asset)
-    assert transaction.quote.buy_asset == offchain_asset.asset
+    assert transaction.quote.sell_asset == asset.asset_identification_format
+    assert transaction.quote.buy_asset == offchain_asset.asset_identification_format
     assert transaction.quote.sell_amount == transaction.amount_in
 
 
@@ -138,14 +138,15 @@ def test_successful_send_firm_quote(client, usd_asset_factory):
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -156,7 +157,7 @@ def test_successful_send_firm_quote(client, usd_asset_factory):
         {
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "quote_id": quote.id,
             "amount": 100,
             "sender_id": "123",
@@ -199,14 +200,15 @@ def test_send_indicative_quote_not_enabled(mock_sep31_ri, client, usd_asset_fact
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     response = client.post(
         transaction_endpoint,
         {
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -233,7 +235,7 @@ def test_send_indicative_quote_no_exchange_pair(
         {
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -257,7 +259,7 @@ def test_send_indicative_quote_no_offchain_asset(
 ):
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset="test:test"
+        sell_asset=asset.asset_identification_format, buy_asset="test:test"
     )
     response = client.post(
         transaction_endpoint,
@@ -285,14 +287,15 @@ def test_send_firm_quote_not_supported(mock_sep31_ri, client, usd_asset_factory)
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -303,7 +306,7 @@ def test_send_firm_quote_not_supported(mock_sep31_ri, client, usd_asset_factory)
         {
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "quote_id": quote.id,
             "amount": 100,
             "sender_id": "123",
@@ -325,14 +328,15 @@ def test_send_firm_quote_no_destination_asset(mock_sep31_ri, client, usd_asset_f
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -368,14 +372,15 @@ def test_send_firm_quote_unknown_destination_asset(
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -412,14 +417,15 @@ def test_send_firm_quote_filters_for_firm_quotes(
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.indicative,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -431,7 +437,7 @@ def test_send_firm_quote_filters_for_firm_quotes(
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
             "quote_id": quote.id,
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -452,14 +458,15 @@ def test_send_firm_quote_needs_matching_id(mock_sep31_ri, client, usd_asset_fact
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -471,7 +478,7 @@ def test_send_firm_quote_needs_matching_id(mock_sep31_ri, client, usd_asset_fact
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
             "quote_id": str(uuid.uuid4()),
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -494,13 +501,14 @@ def test_send_firm_quote_needs_matching_buy_asset(
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
+        sell_asset=asset.asset_identification_format,
         buy_asset="not:test",
         sell_amount=100,
         buy_amount=100,
@@ -513,7 +521,7 @@ def test_send_firm_quote_needs_matching_buy_asset(
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
             "quote_id": str(quote.id),
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -536,14 +544,15 @@ def test_send_firm_quote_needs_matching_auth(mock_sep31_ri, client, usd_asset_fa
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="not source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -555,7 +564,7 @@ def test_send_firm_quote_needs_matching_auth(mock_sep31_ri, client, usd_asset_fa
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
             "quote_id": str(quote.id),
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -576,14 +585,15 @@ def test_send_firm_quote_expired(mock_sep31_ri, client, usd_asset_factory):
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -595,7 +605,7 @@ def test_send_firm_quote_expired(mock_sep31_ri, client, usd_asset_factory):
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
             "quote_id": str(quote.id),
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -616,14 +626,15 @@ def test_send_firm_quote_sell_asset_no_match(mock_sep31_ri, client, usd_asset_fa
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
         sell_asset="stellar:not:match",
-        buy_asset=offchain_asset.asset,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -635,7 +646,7 @@ def test_send_firm_quote_sell_asset_no_match(mock_sep31_ri, client, usd_asset_fa
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
             "quote_id": str(quote.id),
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -658,13 +669,14 @@ def test_send_firm_quote_buy_asset_no_match(mock_sep31_ri, client, usd_asset_fac
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
+        sell_asset=asset.asset_identification_format,
         buy_asset="not:test",
         sell_amount=100,
         buy_amount=100,
@@ -677,7 +689,7 @@ def test_send_firm_quote_buy_asset_no_match(mock_sep31_ri, client, usd_asset_fac
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
             "quote_id": str(quote.id),
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 100,
             "sender_id": "123",
             "receiver_id": "456",
@@ -700,14 +712,15 @@ def test_send_firm_quote_amount_no_match(mock_sep31_ri, client, usd_asset_factor
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     offchain_asset = OffChainAsset.objects.create(scheme="test", identifier="test")
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset=offchain_asset.asset
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
-        buy_asset=offchain_asset.asset,
+        sell_asset=asset.asset_identification_format,
+        buy_asset=offchain_asset.asset_identification_format,
         sell_amount=100,
         buy_amount=100,
         price=1,
@@ -719,7 +732,7 @@ def test_send_firm_quote_amount_no_match(mock_sep31_ri, client, usd_asset_factor
             "asset_code": asset.code,
             "asset_issuer": asset.issuer,
             "quote_id": str(quote.id),
-            "destination_asset": offchain_asset.asset,
+            "destination_asset": offchain_asset.asset_identification_format,
             "amount": 1000,
             "sender_id": "123",
             "receiver_id": "456",
@@ -739,13 +752,13 @@ def test_send_firm_quote_amount_no_match(mock_sep31_ri, client, usd_asset_factor
 def test_send_firm_quote_no_offchain_asset(mock_sep31_ri, client, usd_asset_factory):
     asset = usd_asset_factory(protocols=[Transaction.PROTOCOL.sep31, "sep38"])
     ExchangePair.objects.create(
-        sell_asset=asset_id_format(asset), buy_asset="test:test"
+        sell_asset=asset.asset_identification_format, buy_asset="test:test"
     )
     quote = Quote.objects.create(
         id=str(uuid.uuid4()),
         stellar_account="test source address",
         type=Quote.TYPE.firm,
-        sell_asset=asset_id_format(asset),
+        sell_asset=asset.asset_identification_format,
         buy_asset="test:test",
         sell_amount=100,
         buy_amount=100,

--- a/polaris/polaris/tests/sep31/test_transaction.py
+++ b/polaris/polaris/tests/sep31/test_transaction.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from polaris.tests.helpers import mock_check_auth_success
 from polaris.models import Transaction, Quote
 from polaris.sep31.serializers import SEP31TransactionSerializer
-from polaris.sep38.utils import asset_id_format
 
 
 endpoint = "/sep31/transactions/"
@@ -30,11 +29,11 @@ def test_successful_call(client, acc1_usd_deposit_transaction_factory):
         id=str(uuid.uuid4()),
         stellar_account=transaction.stellar_account,
         type=Quote.TYPE.indicative,
-        sell_asset=asset_id_format(transaction.asset),
+        sell_asset=transaction.asset.asset_identification_format,
         buy_asset="iso4217:USD",
         sell_amount=transaction.amount_in,
     )
-    transaction.fee_asset = asset_id_format(transaction.asset)
+    transaction.fee_asset = transaction.asset.asset_identification_format
     transaction.save()
     response = client.get(endpoint + str(transaction.id))
     serialization = {"transaction": SEP31TransactionSerializer(transaction).data}

--- a/polaris/polaris/tests/sep38/test_info.py
+++ b/polaris/polaris/tests/sep38/test_info.py
@@ -35,7 +35,7 @@ def test_info(client):
 
     expected_usd_stellar = {"asset": f"stellar:{usd_stellar.code}:{usd_stellar.issuer}"}
     expected_brl_offchain = {
-        "asset": brl_offchain.asset,
+        "asset": brl_offchain.asset_identification_format,
         "sell_delivery_methods": [
             {"name": "cash_dropoff", "description": "cash drop-off"}
         ],
@@ -47,7 +47,7 @@ def test_info(client):
     for a in body["assets"]:
         if a["asset"] == expected_usd_stellar["asset"]:
             assert a == expected_usd_stellar, (a, expected_usd_stellar)
-        elif a["asset"] == brl_offchain.asset:
+        elif a["asset"] == brl_offchain.asset_identification_format:
             assert a == expected_brl_offchain, (a, expected_brl_offchain)
         else:
             raise ValueError(f"unexpected asset: {a}")

--- a/polaris/polaris/tests/sep38/test_quote.py
+++ b/polaris/polaris/tests/sep38/test_quote.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 
 from stellar_sdk import Keypair
 
-from polaris.sep38.utils import asset_id_format
 from polaris.sep38.quote import validate_quote_provided
 from polaris.tests.helpers import mock_check_auth_success
 from polaris.models import DeliveryMethod, Asset, OffChainAsset, ExchangePair, Quote
@@ -41,7 +40,8 @@ def default_data():
     ]
     brl_offchain.delivery_methods.add(*delivery_methods)
     pair = ExchangePair.objects.create(
-        buy_asset=asset_id_format(brl_offchain), sell_asset=asset_id_format(usd_stellar)
+        buy_asset=brl_offchain.asset_identification_format,
+        sell_asset=usd_stellar.asset_identification_format,
     )
     return {
         "stellar_assets": [usd_stellar],
@@ -74,8 +74,8 @@ def test_post_quote_success_no_optional_params(mock_rqi, client):
         ENDPOINT,
         json.dumps(
             {
-                "sell_asset": asset_id_format(data["stellar_assets"][0]),
-                "buy_asset": asset_id_format(data["offchain_assets"][0]),
+                "sell_asset": data["stellar_assets"][0].asset_identification_format,
+                "buy_asset": data["offchain_assets"][0].asset_identification_format,
                 "buy_amount": 100,
                 "buy_delivery_method": "cash_pickup",
             }
@@ -90,8 +90,8 @@ def test_post_quote_success_no_optional_params(mock_rqi, client):
         "price": "2.12",
         "buy_amount": "100.00",
         "sell_amount": "212.00",
-        "sell_asset": asset_id_format(data["stellar_assets"][0]),
-        "buy_asset": asset_id_format(data["offchain_assets"][0]),
+        "sell_asset": data["stellar_assets"][0].asset_identification_format,
+        "buy_asset": data["offchain_assets"][0].asset_identification_format,
     }
     q = Quote.objects.get(id=quote_id)
     assert q
@@ -124,9 +124,9 @@ def test_post_quote_success_country_code_buy_delivery_method_expire_after(
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "country_code": "BRA",
             "buy_delivery_method": "cash_pickup",
             "expire_after": expire_after.strftime(DATETIME_FORMAT),
@@ -141,8 +141,8 @@ def test_post_quote_success_country_code_buy_delivery_method_expire_after(
         "price": "2.12",
         "sell_amount": "100.00",
         "buy_amount": str(round(Decimal(100) / Decimal("2.12"), 2)),
-        "sell_asset": asset_id_format(data["stellar_assets"][0]),
-        "buy_asset": asset_id_format(data["offchain_assets"][0]),
+        "sell_asset": data["stellar_assets"][0].asset_identification_format,
+        "buy_asset": data["offchain_assets"][0].asset_identification_format,
     }
     assert Quote.objects.get(id=quote_id)
 
@@ -173,8 +173,8 @@ def test_post_quote_success_country_code_sell_delivery_method(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["offchain_assets"][0]),
-            "buy_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["offchain_assets"][0].asset_identification_format,
+            "buy_asset": data["stellar_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "country_code": "BRA",
             "sell_delivery_method": "cash_dropoff",
@@ -189,8 +189,8 @@ def test_post_quote_success_country_code_sell_delivery_method(mock_rqi, client):
         "price": "2.12",
         "buy_amount": "100.00",
         "sell_amount": "212.00",
-        "buy_asset": asset_id_format(data["stellar_assets"][0]),
-        "sell_asset": asset_id_format(data["offchain_assets"][0]),
+        "buy_asset": data["stellar_assets"][0].asset_identification_format,
+        "sell_asset": data["offchain_assets"][0].asset_identification_format,
     }
     assert Quote.objects.get(id=quote_id)
 
@@ -220,9 +220,9 @@ def test_post_quote_success_no_optional_params_swap_exchange_pair(mock_rqi, clie
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["offchain_assets"][0].asset_identification_format,
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["stellar_assets"][0]),
+            "buy_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_delivery_method": "cash_dropoff",
         },
         content_type="application/json",
@@ -235,8 +235,8 @@ def test_post_quote_success_no_optional_params_swap_exchange_pair(mock_rqi, clie
         "price": "2.12",
         "sell_amount": "100.00",
         "buy_amount": str(round(Decimal(100) / Decimal("2.12"), 2)),
-        "buy_asset": asset_id_format(data["stellar_assets"][0]),
-        "sell_asset": asset_id_format(data["offchain_assets"][0]),
+        "buy_asset": data["stellar_assets"][0].asset_identification_format,
+        "sell_asset": data["offchain_assets"][0].asset_identification_format,
     }
     assert Quote.objects.get(id=quote_id)
 
@@ -251,8 +251,8 @@ def test_post_quote_failure_both_amounts(mock_rqi, client):
         ENDPOINT,
         json.dumps(
             {
-                "sell_asset": asset_id_format(data["stellar_assets"][0]),
-                "buy_asset": asset_id_format(data["offchain_assets"][0]),
+                "sell_asset": data["stellar_assets"][0].asset_identification_format,
+                "buy_asset": data["offchain_assets"][0].asset_identification_format,
                 "buy_amount": 100,
                 "sell_amount": 100,
                 "buy_delivery_method": "cash_pickup",
@@ -275,8 +275,8 @@ def test_post_quote_failure_no_exchange_pairs(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["offchain_assets"][0]),
-            "buy_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["offchain_assets"][0].asset_identification_format,
+            "buy_asset": data["stellar_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "sell_delivery_method": "cash_dropoff",
         },
@@ -296,7 +296,7 @@ def test_post_quote_failure_missing_sell_asset(mock_rqi, client):
         ENDPOINT,
         {
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_delivery_method": "cash_pickup",
         },
         content_type="application/json",
@@ -316,7 +316,7 @@ def test_post_quote_failure_missing_buy_asset(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "buy_delivery_method": "cash_pickup",
         },
@@ -337,9 +337,9 @@ def test_post_quote_failure_both_delivery_methods(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_delivery_method": "cash_pickup",
             "sell_delivery_method": "cash_dropoff",
         },
@@ -360,9 +360,9 @@ def test_post_quote_failure_sell_stellar_with_sell_delivery_method(mock_rqi, cli
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "sell_delivery_method": "cash_dropoff",
         },
         content_type="application/json",
@@ -388,8 +388,8 @@ def test_post_quote_failure_sell_offchain_with_buy_delivery_method(mock_rqi, cli
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["offchain_assets"][0]),
-            "buy_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["offchain_assets"][0].asset_identification_format,
+            "buy_asset": data["stellar_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "buy_delivery_method": "cash_pickup",
         },
@@ -411,7 +411,7 @@ def test_post_quote_failure_bad_sell_stellar_format(mock_rqi, client):
         ENDPOINT,
         {
             "sell_asset": f"stellar:USDC",
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "buy_delivery_method": "cash_pickup",
         },
@@ -431,7 +431,7 @@ def test_post_quote_failure_bad_buy_stellar_format(mock_rqi, client):
         ENDPOINT,
         {
             "buy_asset": f"stellar:USDC",
-            "sell_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["offchain_assets"][0].asset_identification_format,
             "sell_amount": 100,
             "sell_delivery_method": "cash_dropoff",
         },
@@ -452,7 +452,7 @@ def test_post_quote_failure_bad_sell_offchain_format(mock_rqi, client):
         {
             "sell_asset": f"USD",
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["stellar_assets"][0]),
+            "buy_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_delivery_method": "cash_dropoff",
         },
         content_type="application/json",
@@ -472,7 +472,7 @@ def test_post_quote_failure_bad_buy_offchain_format(mock_rqi, client):
         {
             "buy_asset": f"USD",
             "buy_amount": 100,
-            "sell_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["offchain_assets"][0].asset_identification_format,
             "sell_delivery_method": "cash_dropoff",
         },
         content_type="application/json",
@@ -494,8 +494,8 @@ def test_post_quote_failure_stellar_asset_not_found(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "buy_delivery_method": "cash_dropoff",
         },
@@ -524,8 +524,8 @@ def test_post_quote_failure_offchain_asset_not_found(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["offchain_assets"][0]),
-            "buy_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["offchain_assets"][0].asset_identification_format,
+            "buy_asset": data["stellar_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "sell_delivery_method": "cash_dropoff",
         },
@@ -547,8 +547,8 @@ def test_post_quote_failure_bad_buy_delivery_method(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "buy_delivery_method": "bad_delivery_method",
         },
@@ -570,9 +570,9 @@ def test_post_quote_failure_bad_country_code(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "country_code": "TEST",
             "buy_delivery_method": "cash_pickup",
         },
@@ -598,8 +598,8 @@ def test_post_quote_failure_bad_sell_delivery_method(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["offchain_assets"][0]),
-            "buy_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["offchain_assets"][0].asset_identification_format,
+            "buy_asset": data["stellar_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "sell_delivery_method": "bad_delivery_method",
         },
@@ -621,9 +621,9 @@ def test_post_quote_failure_bad_sell_amount(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_amount": "test",
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_delivery_method": "cash_pickup",
         },
         content_type="application/json",
@@ -644,8 +644,8 @@ def test_post_quote_failure_bad_buy_amount(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_amount": "test",
             "buy_delivery_method": "cash_pickup",
         },
@@ -667,8 +667,8 @@ def test_post_quote_failure_bad_expires_at(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "expire_after": "test",
             "buy_delivery_method": "cash_pickup",
@@ -691,9 +691,9 @@ def test_post_quote_failure_expires_at_in_past(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "expire_after": (datetime.now(timezone.utc) - timedelta(hours=1)).strftime(
                 DATETIME_FORMAT
             ),
@@ -718,9 +718,9 @@ def test_post_quote_failure_anchor_raises_value_error(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
             "sell_amount": 100,
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_delivery_method": "cash_pickup",
         },
         content_type="application/json",
@@ -744,8 +744,8 @@ def test_post_quote_failure_anchor_raises_runtime_error(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "buy_delivery_method": "cash_pickup",
         },
@@ -771,9 +771,9 @@ def test_post_quote_failure_anchor_raises_unexpected_error(mock_rqi, client):
         client.post(
             ENDPOINT,
             {
-                "sell_asset": asset_id_format(data["stellar_assets"][0]),
+                "sell_asset": data["stellar_assets"][0].asset_identification_format,
                 "sell_amount": 100,
-                "buy_asset": asset_id_format(data["offchain_assets"][0]),
+                "buy_asset": data["offchain_assets"][0].asset_identification_format,
                 "buy_delivery_method": "cash_pickup",
             },
             content_type="application/json",
@@ -795,8 +795,8 @@ def test_post_quote_failure_anchor_provides_bad_quote(mock_rqi, client):
     response = client.post(
         ENDPOINT,
         {
-            "sell_asset": asset_id_format(data["stellar_assets"][0]),
-            "buy_asset": asset_id_format(data["offchain_assets"][0]),
+            "sell_asset": data["stellar_assets"][0].asset_identification_format,
+            "buy_asset": data["offchain_assets"][0].asset_identification_format,
             "buy_amount": 100,
             "buy_delivery_method": "cash_pickup",
         },
@@ -1170,8 +1170,8 @@ def test_get_quote_success(client):
     data = default_data()
     quote = Quote.objects.create(
         type=Quote.TYPE.firm,
-        buy_asset=asset_id_format(data["offchain_assets"][0]),
-        sell_asset=asset_id_format(data["stellar_assets"][0]),
+        buy_asset=data["offchain_assets"][0].asset_identification_format,
+        sell_asset=data["stellar_assets"][0].asset_identification_format,
         buy_amount=Decimal(100),
         sell_amount=Decimal(100),
         price=Decimal("2.12"),
@@ -1183,8 +1183,8 @@ def test_get_quote_success(client):
     assert response.json() == {
         "id": str(quote.id),
         "expires_at": quote.expires_at.strftime(DATETIME_FORMAT),
-        "buy_asset": asset_id_format(data["offchain_assets"][0]),
-        "sell_asset": asset_id_format(data["stellar_assets"][0]),
+        "buy_asset": data["offchain_assets"][0].asset_identification_format,
+        "sell_asset": data["stellar_assets"][0].asset_identification_format,
         "price": "2.12",
         "sell_amount": "100.00",
         "buy_amount": "100.00",

--- a/polaris/polaris/utils.py
+++ b/polaris/polaris/utils.py
@@ -23,7 +23,7 @@ from aiohttp import ClientResponse
 from polaris import settings
 from polaris.models import Transaction, Asset, Quote, OffChainAsset, ExchangePair
 from polaris.sep10.token import SEP10Token
-from polaris.sep38.utils import asset_id_format, asset_id_to_kwargs
+from polaris.sep38.utils import asset_id_to_kwargs
 from polaris.shared.serializers import TransactionSerializer
 
 
@@ -385,7 +385,7 @@ def get_quote_and_offchain_destination_asset(
             raise ValueError(_("quote not found"))
         if quote.expires_at < datetime.now(timezone.utc):
             raise ValueError(_("quote has expired"))
-        if quote.sell_asset != asset_id_format(asset):
+        if quote.sell_asset != asset.asset_identification_format:
             raise ValueError(
                 _(
                     "quote 'sell_asset' does not match 'asset_code' and 'asset_issuer' parameters"
@@ -407,7 +407,8 @@ def get_quote_and_offchain_destination_asset(
         if "sep-38" not in settings.ACTIVE_SEPS or not asset.sep38_enabled:
             raise ValueError(_("quotes are not supported"))
         if not ExchangePair.objects.filter(
-            sell_asset=asset_id_format(asset), buy_asset=destination_asset_str
+            sell_asset=asset.asset_identification_format,
+            buy_asset=destination_asset_str,
         ).exists():
             raise ValueError(
                 _("unsupported 'destination_asset' for 'asset_code' and 'asset_issuer'")
@@ -424,7 +425,7 @@ def get_quote_and_offchain_destination_asset(
             stellar_account=token.account,
             account_memo=token.memo,
             muxed_account=token.muxed_account,
-            sell_asset=asset_id_format(asset),
+            sell_asset=asset.asset_identification_format,
             buy_asset=destination_asset_str,
             sell_amount=amount,
         )
@@ -459,7 +460,7 @@ def get_quote_and_offchain_source_asset(
             raise ValueError(_("quote not found"))
         if quote.expires_at < datetime.now(timezone.utc):
             raise ValueError(_("quote has expired"))
-        if quote.buy_asset != asset_id_format(asset):
+        if quote.buy_asset != asset.asset_identification_format:
             raise ValueError(
                 _(
                     "quote 'buy_asset' does not match 'asset_code' and 'asset_issuer' parameters"
@@ -481,7 +482,7 @@ def get_quote_and_offchain_source_asset(
         if "sep-38" not in settings.ACTIVE_SEPS or not asset.sep38_enabled:
             raise ValueError(_("quotes are not supported"))
         if not ExchangePair.objects.filter(
-            sell_asset=source_asset_str, buy_asset=asset_id_format(asset)
+            sell_asset=source_asset_str, buy_asset=asset.asset_identification_format
         ).exists():
             raise ValueError(
                 _("unsupported 'source_asset' for 'asset_code' and 'asset_issuer'")
@@ -498,7 +499,7 @@ def get_quote_and_offchain_source_asset(
             stellar_account=token.account,
             account_memo=token.memo,
             muxed_account=token.muxed_account,
-            buy_asset=asset_id_format(asset),
+            buy_asset=asset.asset_identification_format,
             sell_asset=source_asset_str,
             sell_amount=amount,
         )


### PR DESCRIPTION
Lots of files but a very simple change:

- Added `asset_identification_format` properties to both `Asset` and `OffChainAsset`
- Replaced usage of `OffChain.asset` and `asset_id_format()` with the new properties