### PR TITLE
reference server: remove bad imports

### DIFF
--- a/example/server/integrations/deposit.py
+++ b/example/server/integrations/deposit.py
@@ -12,7 +12,6 @@ from stellar_sdk import Keypair
 from polaris.integrations import DepositIntegration, TransactionForm, calculate_fee
 from polaris.models import Transaction, Asset, Quote, OffChainAsset
 from polaris.sep10.token import SEP10Token
-from polaris.sep38.utils import asset_id_format
 from polaris.templates import Template
 from polaris.utils import getLogger
 from .mock_exchange import get_mock_firm_exchange_price

--- a/example/server/integrations/sep31.py
+++ b/example/server/integrations/sep31.py
@@ -7,7 +7,6 @@ from rest_framework.request import Request
 from polaris.integrations import SEP31ReceiverIntegration
 from polaris.models import Asset, Transaction
 from polaris.sep10.token import SEP10Token
-from polaris.sep38.utils import asset_id_format
 
 from ..models import PolarisUser, PolarisUserTransaction
 

--- a/example/server/integrations/withdraw.py
+++ b/example/server/integrations/withdraw.py
@@ -9,7 +9,6 @@ from rest_framework.request import Request
 from polaris.integrations import WithdrawalIntegration, calculate_fee
 from polaris.models import Transaction, Asset, Quote, OffChainAsset
 from polaris.sep10.token import SEP10Token
-from polaris.sep38.utils import asset_id_format
 from polaris.templates import Template
 from polaris.utils import getLogger
 from polaris import settings


### PR DESCRIPTION
The lasted commit to master failed at the deployment stage because there were bad imports I forgot to remove. This commit removes them.