### PR TITLE
SEP-24: optionally ignore SEP-9 fields passed

### DIFF
--- a/polaris/polaris/sep24/deposit.py
+++ b/polaris/polaris/sep24/deposit.py
@@ -451,10 +451,9 @@ def deposit(token: SEP10Token, request: Request) -> Response:
             # specified in the request.
             return render_error_response(str(e))
         except NotImplementedError:
-            return render_error_response(
-                "passing SEP-9 fields in deposit requests is not supported",
-                status_code=501,
-            )
+            # the KYC info passed via SEP-9 fields can be ignored if the anchor
+            # wants to re-collect the information
+            pass
 
     # Construct interactive deposit pop-up URL.
     transaction_id = create_transaction_id()

--- a/polaris/polaris/sep24/withdraw.py
+++ b/polaris/polaris/sep24/withdraw.py
@@ -442,10 +442,9 @@ def withdraw(token: SEP10Token, request: Request,) -> Response:
             # specified in the request.
             return render_error_response(str(e))
         except NotImplementedError:
-            return render_error_response(
-                "passing SEP-9 fields in withdraw requests is not supported",
-                status_code=501,
-            )
+            # the KYC info passed via SEP-9 fields can be ignored if the anchor
+            # wants to re-collect the information
+            pass
 
     transaction_id = create_transaction_id()
     Transaction.objects.create(


### PR DESCRIPTION
This change was just pushed in a 2.0.7 release. Reported by Lobstr, Polaris should ignore the SEP-9 parameters passed to SEP-24 `/deposit` and `/withdraw` endpoints if the anchor has not implemented the `.save_sep9_fields()` integration.