### PR TITLE
transaction streaming: check paging token value

### DIFF
--- a/polaris/polaris/management/commands/watch_transactions.py
+++ b/polaris/polaris/management/commands/watch_transactions.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
             )()
 
             cursor = "0"
-            if last_completed_transaction:
+            if last_completed_transaction and last_completed_transaction.paging_token:
                 cursor = last_completed_transaction.paging_token
 
             logger.info(


### PR DESCRIPTION
Polaris assumes that if a transaction is complete, it has a paging token, which is a fair assumption on mainnet. But on testnet, if the last completed transaction was prior to a testnet reset, it won't. This added condition accounts for that and uses "0" as the streaming cursor in those cases.