### PR TITLE
Save transaction envelope prior to submission

### DIFF
--- a/polaris/polaris/management/commands/process_pending_deposits.py
+++ b/polaris/polaris/management/commands/process_pending_deposits.py
@@ -630,7 +630,6 @@ class PendingDeposits:
         elif transaction.claimable_balance_supported:
             transaction.claimable_balance_id = cls.get_balance_id(response)
 
-        # transaction.envelope_xdr = response["envelope_xdr"]
         transaction.paging_token = response["paging_token"]
         transaction.stellar_transaction_id = response["id"]
         transaction.status = Transaction.STATUS.completed

--- a/polaris/polaris/management/commands/process_pending_deposits.py
+++ b/polaris/polaris/management/commands/process_pending_deposits.py
@@ -599,6 +599,7 @@ class PendingDeposits:
                     transaction, distribution_acc, server
                 )
                 envelope.sign(transaction.asset.distribution_seed)
+                transaction.envelope_xdr = envelope.to_xdr()
 
             transaction.status = Transaction.STATUS.pending_stellar
             await sync_to_async(transaction.save)()
@@ -629,7 +630,7 @@ class PendingDeposits:
         elif transaction.claimable_balance_supported:
             transaction.claimable_balance_id = cls.get_balance_id(response)
 
-        transaction.envelope_xdr = response["envelope_xdr"]
+        # transaction.envelope_xdr = response["envelope_xdr"]
         transaction.paging_token = response["paging_token"]
         transaction.stellar_transaction_id = response["id"]
         transaction.status = Transaction.STATUS.completed

--- a/polaris/polaris/tests/commands/test_poll_pending_deposits.py
+++ b/polaris/polaris/tests/commands/test_poll_pending_deposits.py
@@ -598,7 +598,10 @@ async def test_submit_sucess():
                     await sync_to_async(transaction.refresh_from_db)()
                     assert transaction.status == Transaction.STATUS.completed
                     assert transaction.pending_execution_attempt is False
-                    assert transaction.envelope_xdr == "envelope_xdr"
+                    assert (
+                        transaction.envelope_xdr
+                        == mock_create_deposit_envelope.return_value.to_xdr()
+                    )
                     assert transaction.paging_token == "paging_token"
                     assert transaction.stellar_transaction_id == "id"
                     assert transaction.completed_at
@@ -676,11 +679,14 @@ async def test_submit_request_failed_bad_request():
                     assert transaction.status == Transaction.STATUS.error
                     assert transaction.status_message == "BadRequestError: testing"
                     assert transaction.pending_execution_attempt is False
-                    assert transaction.envelope_xdr is None
                     assert transaction.paging_token is None
                     assert transaction.stellar_transaction_id is None
                     assert transaction.completed_at is None
                     assert transaction.amount_out is None
+                    assert (
+                        transaction.envelope_xdr
+                        == mock_create_deposit_envelope.return_value.to_xdr()
+                    )
 
                     server.submit_transaction.assert_called_once_with(
                         mock_create_deposit_envelope.return_value
@@ -751,11 +757,14 @@ async def test_submit_request_failed_connection_failed():
                     assert transaction.status == Transaction.STATUS.error
                     assert transaction.status_message == "ConnectionError: testing"
                     assert transaction.pending_execution_attempt is False
-                    assert transaction.envelope_xdr is None
                     assert transaction.paging_token is None
                     assert transaction.stellar_transaction_id is None
                     assert transaction.completed_at is None
                     assert transaction.amount_out is None
+                    assert (
+                        transaction.envelope_xdr
+                        == mock_create_deposit_envelope.return_value.to_xdr()
+                    )
 
                     server.submit_transaction.assert_called_once_with(
                         mock_create_deposit_envelope.return_value
@@ -831,7 +840,10 @@ async def test_submit_request_unsuccessful():
                         == "Stellar transaction failed when submitted to horizon: testing"
                     )
                     assert transaction.pending_execution_attempt is False
-                    assert transaction.envelope_xdr is None
+                    assert (
+                        transaction.envelope_xdr
+                        == mock_create_deposit_envelope.return_value.to_xdr()
+                    )
                     assert transaction.paging_token is None
                     assert transaction.stellar_transaction_id is None
                     assert transaction.completed_at is None
@@ -905,7 +917,7 @@ async def test_submit_multisig_success():
                     await sync_to_async(transaction.refresh_from_db)()
                     assert transaction.status == Transaction.STATUS.completed
                     assert transaction.pending_execution_attempt is False
-                    assert transaction.envelope_xdr == "envelope_xdr"
+                    assert transaction.envelope_xdr == envelope.to_xdr()
                     assert transaction.paging_token == "paging_token"
                     assert transaction.stellar_transaction_id == "id"
                     assert transaction.completed_at


### PR DESCRIPTION
Saves the transaction envelope before submitting it to Stellar.

Previously, Polaris saved transaction envelopes after receiving a successful response from horizon. However, if transaction submission fails, the envelope submitted would not be saved to the database. This can be a problem if anchors try to re-process a deposit transaction that failed on the first attempt due to timeout errors.

If an anchor's distribution account requires multiple signatures prior submission, the above does not apply.