### PR TITLE
SEP-24 asset symbol styling

### DIFF
--- a/polaris/polaris/static/polaris/form-styles/forms.scss
+++ b/polaris/polaris/static/polaris/form-styles/forms.scss
@@ -75,10 +75,11 @@
 
   & .icon {
     position: absolute;
-    padding: 1rem 0;
+    padding: 1rem;
     line-height: 1.125rem;
-    padding-left: 1rem;
     font-weight: $bold-weight;
+    border-radius: 0.75rem 0 0 0.75rem;
+    background-color: #484848;
   }
 
   input[type="text"],

--- a/polaris/polaris/static/polaris/scripts/dynamicAmountPadding.js
+++ b/polaris/polaris/static/polaris/scripts/dynamicAmountPadding.js
@@ -2,9 +2,10 @@
 
 // Amount symbol padding
 const amountSymbol = document.querySelector('.icon-symbol');
-let amountInputElem, amountSymbolWidthFloat;
 if (amountSymbol) {
-  amountInputElem = amountSymbol.nextElementSibling;
-  amountSymbolWidthFloat = parseFloat(getComputedStyle(amountSymbol).width.replace(/px/, ''));
-  amountInputElem.style.paddingLeft = (amountSymbolWidthFloat + 2).toString() + 'px';
+  const style = getComputedStyle(amountSymbol);
+  const width = parseFloat(style.width.replace(/px/, ''));
+  const paddingRight = parseFloat(style.paddingRight.replace(/px/, ''));
+  const amountInputElem = amountSymbol.nextElementSibling;
+  amountInputElem.style.paddingLeft = (width + paddingRight).toString() + 'px';
 }

--- a/polaris/polaris/static/polaris/scripts/dynamicAmountPadding.js
+++ b/polaris/polaris/static/polaris/scripts/dynamicAmountPadding.js
@@ -2,10 +2,11 @@
 
 // Amount symbol padding
 const amountSymbol = document.querySelector('.icon-symbol');
+let style, width, paddingRight, amountInputElem;
 if (amountSymbol) {
-  const style = getComputedStyle(amountSymbol);
-  const width = parseFloat(style.width.replace(/px/, ''));
-  const paddingRight = parseFloat(style.paddingRight.replace(/px/, ''));
-  const amountInputElem = amountSymbol.nextElementSibling;
+  style = getComputedStyle(amountSymbol);
+  width = parseFloat(style.width.replace(/px/, ''));
+  paddingRight = parseFloat(style.paddingRight.replace(/px/, ''));
+  amountInputElem = amountSymbol.nextElementSibling;
   amountInputElem.style.paddingLeft = (width + paddingRight).toString() + 'px';
 }


### PR DESCRIPTION
Improve asset symbol appearance inside the amount input.

Current:
![Screenshot_15](https://user-images.githubusercontent.com/26092447/145497465-0f4202c2-56f3-425f-bae9-e7d9b066b666.png)

Proposed by this pull request:
![Screenshot_14](https://user-images.githubusercontent.com/26092447/145497494-cb4fd7be-8b63-4c1b-befd-df4ff17eece3.png)
