### PR TITLE
bug: Add QUOTE_SERVER to stellar.toml

### DIFF
--- a/polaris/polaris/integrations/toml.py
+++ b/polaris/polaris/integrations/toml.py
@@ -26,6 +26,7 @@ def get_stellar_toml(request: Request, *args: List, **kwargs: Dict):
     - `TRANSFER_SERVER_0024`
     - `KYC_SERVER`
     - `DIRECT_PAYMENT_SERVER`
+    - `QUOTE_SERVER`
 
     The contents of the dictionary returned will overwrite the default matching key values.
 

--- a/polaris/polaris/sep1/views.py
+++ b/polaris/polaris/sep1/views.py
@@ -75,6 +75,8 @@ def generate_toml(request: Request) -> Response:
         toml_dict["KYC_SERVER"] = os.path.join(settings.HOST_URL, "kyc")
     if "sep-31" in settings.ACTIVE_SEPS:
         toml_dict["DIRECT_PAYMENT_SERVER"] = os.path.join(settings.HOST_URL, "sep31")
+    if "sep-38" in settings.ACTIVE_SEPS:
+        toml_dict["QUOTE_SERVER"] = os.path.join(settings.HOST_URL, "sep38")
 
     toml_dict.update(registered_toml_func(request))
     content = toml.dumps(toml_dict)


### PR DESCRIPTION
When anchors use an integration function to specify the stellar info file's content, Polaris automatically populates many standardized attributes. However, `QUOTE_SERVER` was not being added to the toml file when appropriate.