### PR TITLE
Added support for form field.help_text

### DIFF
--- a/polaris/polaris/static/polaris/form-styles/forms.scss
+++ b/polaris/polaris/static/polaris/form-styles/forms.scss
@@ -69,6 +69,12 @@
   font-size: 0.875rem;
 }
 
+.help-text {
+  color: grey;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+}
+
 .control {
   position: relative;
   cursor: pointer;

--- a/polaris/polaris/templates/polaris/deposit.html
+++ b/polaris/polaris/templates/polaris/deposit.html
@@ -33,6 +33,9 @@
       </div>
 
       <div class="control">{{ field }}</div>
+      {% if field.help_text %}
+        <div class="help-text">{{ field.help_text }}</div>
+      {% endif %}
 
       {% if field.errors %}
       <p class="help is-danger">

--- a/polaris/polaris/templates/polaris/withdraw.html
+++ b/polaris/polaris/templates/polaris/withdraw.html
@@ -33,6 +33,9 @@
       </div>
 
       <div class="control">{{ field }}</div>
+      {% if field.help_text %}
+        <div class="help-text">{{ field.help_text }}</div>
+      {% endif %}
 
       {% if field.errors %}
       <p class="help is-danger">


### PR DESCRIPTION
This allows displaying `field.help_text` below the field input:

![Screenshot_20](https://user-images.githubusercontent.com/26092447/148244432-1d50d782-4270-4bee-b560-b315d70adce2.png)
