### PR TITLE
update CSS for SEP-24 interactive flow

### DIFF
--- a/polaris/polaris/static/polaris/base.css
+++ b/polaris/polaris/static/polaris/base.css
@@ -534,15 +534,21 @@ template {
   padding: 0.25rem 0.5rem;
   font-size: 0.875rem; }
 
+.help-text {
+  color: grey;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem; }
+
 .control {
   position: relative;
   cursor: pointer; }
   .control .icon {
     position: absolute;
-    padding: 1rem 0;
+    padding: 1rem;
     line-height: 1.125rem;
-    padding-left: 1rem;
-    font-weight: 700; }
+    font-weight: 700;
+    border-radius: 0.75rem 0 0 0.75rem;
+    background-color: #727b84; }
   .control input[type="text"],
   .control input[type="number"],
   .control input[type="date"],

--- a/polaris/polaris/static/polaris/form-styles/forms.scss
+++ b/polaris/polaris/static/polaris/form-styles/forms.scss
@@ -3,6 +3,7 @@
 @import "./file-picker.scss";
 @import "./select-list.scss";
 @import "./toggle.scss";
+@import "../colors.scss";
 
 .field {
   margin: 1rem 0;
@@ -85,7 +86,7 @@
     line-height: 1.125rem;
     font-weight: $bold-weight;
     border-radius: 0.75rem 0 0 0.75rem;
-    background-color: #484848;
+    background-color: $light-gray;
   }
 
   input[type="text"],


### PR DESCRIPTION
Builds on the work @yuriescl did to improve the SEP-24 amount field. Compiles the SCSS files and uses our `$light-gray` color vs the custom color originally set.