### PR TITLE
bug fixes: don't require SEP-12 'account' request parameter and always pass 'memo' as a string

### DIFF
--- a/polaris/polaris/integrations/customers.py
+++ b/polaris/polaris/integrations/customers.py
@@ -42,10 +42,7 @@ class CustomerIntegration:
         .. _ObjectDoesNotExist: https://docs.djangoproject.com/en/3.1/ref/exceptions/#objectdoesnotexist
 
         Return a dictionary matching the response schema outlined in `SEP-12 GET /customer`_
-        based on the `params` passed. The key-value pairs in `params` match the arguments
-        sent in the request with the exception of ``sep10_client_account``. This parameter
-        was added in preparation for a future change. For now, ``sep10_client_account`` will
-        always match ``account``.
+        based on the `params` passed.
 
         Raise a ``ValueError`` if the parameters are invalid, or raise an
         ObjectDoesNotExist_ exception if the customer specified via the ``id`` parameter

--- a/polaris/polaris/tests/sep12/test_customer.py
+++ b/polaris/polaris/tests/sep12/test_customer.py
@@ -64,7 +64,7 @@ def test_put_success_auth_memo(mock_rci, client):
     assert kwargs["token"].muxed_account is None
     assert kwargs["token"].memo == TEST_ACCOUNT_MEMO
     assert kwargs["params"]["account"] == kwargs["token"].account
-    assert kwargs["params"]["memo"] == kwargs["token"].memo
+    assert kwargs["params"]["memo"] == str(kwargs["token"].memo)
     assert kwargs["params"]["memo_type"] == "id"
     assert response.status_code == 202, content
     assert content == {"id": "123"}
@@ -92,7 +92,7 @@ def test_put_success_auth_memo_and_body(mock_rci, client):
     assert kwargs["token"].muxed_account is None
     assert kwargs["token"].memo == TEST_ACCOUNT_MEMO
     assert kwargs["params"]["account"] == kwargs["token"].account
-    assert kwargs["params"]["memo"] == kwargs["token"].memo
+    assert kwargs["params"]["memo"] == str(kwargs["token"].memo)
     assert kwargs["params"]["memo_type"] == "id"
     assert response.status_code == 202, content
     assert content == {"id": "123"}
@@ -120,7 +120,7 @@ def test_put_success_memo_in_body_no_auth(mock_rci, client):
     assert kwargs["token"].muxed_account is None
     assert kwargs["token"].memo is None
     assert kwargs["params"]["account"] == kwargs["token"].account
-    assert kwargs["params"]["memo"] == TEST_ACCOUNT_MEMO
+    assert kwargs["params"]["memo"] == str(TEST_ACCOUNT_MEMO)
     assert kwargs["params"]["memo_type"] == "id"
     assert response.status_code == 202, content
     assert content == {"id": "123"}
@@ -827,7 +827,7 @@ def test_delete_success_with_memo_auth(mock_delete, client):
     assert kwargs["token"].muxed_account is None
     assert kwargs["token"].memo is TEST_ACCOUNT_MEMO
     assert kwargs["account"] == kwargs["token"].account
-    assert kwargs["memo"] == kwargs["token"].memo
+    assert kwargs["memo"] == str(kwargs["token"].memo)
     assert kwargs["memo_type"] == "id"
 
 
@@ -846,7 +846,7 @@ def test_delete_success_with_memo_auth_and_body(mock_delete, client):
     assert kwargs["token"].muxed_account is None
     assert kwargs["token"].memo is TEST_ACCOUNT_MEMO
     assert kwargs["account"] == kwargs["token"].account
-    assert kwargs["memo"] == kwargs["token"].memo
+    assert kwargs["memo"] == str(kwargs["token"].memo)
     assert kwargs["memo_type"] == "id"
 
 
@@ -865,7 +865,7 @@ def test_delete_success_with_memo_in_body_no_auth(mock_delete, client):
     assert kwargs["token"].muxed_account is None
     assert kwargs["token"].memo is None
     assert kwargs["account"] == kwargs["token"].account
-    assert kwargs["memo"] == TEST_ACCOUNT_MEMO
+    assert kwargs["memo"] == str(TEST_ACCOUNT_MEMO)
     assert kwargs["memo_type"] == "id"
 
 


### PR DESCRIPTION
Currently, Polaris requires the `account` SEP-12 request parameter to match account authenticated via SEP-10. However, the SEP states that the `account` request parameter doesn't need to be specified since it is redundant.

This PR updates the request validation logic to only check for a match between account values if the `account` request parameter is provided.

It also ensures that the `memo` value passed to SEP-12 integration functions is always a string. Currently, Polaris will pass `memo` as an integer if `memo_type` is `id`. 