### PR TITLE
update packaging home page

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ version = attr: polaris.__version__
 description = An extendable Django server for Stellar Ecosystem Proposals.
 long_description = file: README.rst
 long_description_content_type = text/x-rst
-url = django-polaris.readthedocs.io/en/stable
+url = https://django-polaris.readthedocs.io/en/stable
 author = Stellar Development Foundation
 author_email = jake@stellar.org
 license = Apache license 2.0
@@ -23,7 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 project_urls =
-    Documentation = django-polaris.readthedocs.io/en/stable
+    Documentation = https://django-polaris.readthedocs.io/en/stable
     Release notes = https://github.com/stellar/django-polaris/releases
     Bug Tracker = https://github.com/stellar/django-polaris/issues
 keywords =


### PR DESCRIPTION
Adds the `https://` prefix to Polaris' documentation URLs in the packaging configuration. PyPi requested requests to upload a new release without this prefix.