### PR TITLE
remove content_type= kwarg from Response objects

### DIFF
--- a/polaris/polaris/utils.py
+++ b/polaris/polaris/utils.py
@@ -62,11 +62,7 @@ def render_error_response(
 
     Currently supports HTML or JSON responses.
     """
-    resp_data = {
-        "data": {"error": description},
-        "status": status_code,
-        "content_type": content_type,
-    }
+    resp_data = {"data": {"error": description}, "status": status_code}
     if content_type == "text/html":
         resp_data["data"]["status_code"] = str(status_code)
         resp_data["template_name"] = "polaris/error.html"


### PR DESCRIPTION
The `content_type` keyword argument returned from `render_error_response()` and passed to the `Response()` objects Django uses to render content to the client conflicts with the rendering classes set on all endpoints.

Removing this keyword argument ensures that the content rendered to the client is solely determined by the content negotiation process Django uses automatically.