### PR TITLE
update logging format

### DIFF
--- a/example/server/settings.py
+++ b/example/server/settings.py
@@ -154,7 +154,11 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": True,
     "formatters": {
-        "verbose": {"format": "{asctime} - {levelname}: {message}", "style": "{",},
+        "verbose": {
+            "format": "{asctime} - {levelname} - {name}:{lineno} - {message}",
+            "style": "{",
+            "datefmt": "%Y-%m-%dT%H:%M:%SZ",
+        },
     },
     "handlers": {
         "console": {

--- a/polaris/polaris/utils.py
+++ b/polaris/polaris/utils.py
@@ -3,8 +3,8 @@ import json
 import codecs
 import uuid
 from datetime import datetime, timezone
+from logging import getLogger
 from typing import Optional, Union, Tuple, Dict
-from logging import getLogger as get_logger, LoggerAdapter
 from decimal import Decimal
 
 import aiohttp
@@ -38,15 +38,6 @@ from polaris.models import Transaction, Asset, Quote, OffChainAsset, ExchangePai
 from polaris.sep10.token import SEP10Token
 from polaris.sep38.utils import asset_id_to_kwargs
 from polaris.shared.serializers import TransactionSerializer
-
-
-class PolarisLoggerAdapter(LoggerAdapter):
-    def process(self, msg, kwargs):
-        return f"{self.extra['python_path']}: {msg}", kwargs
-
-
-def getLogger(name):
-    return PolarisLoggerAdapter(get_logger(name), extra={"python_path": name})
 
 
 logger = getLogger(__name__)

--- a/polaris/settings.py
+++ b/polaris/settings.py
@@ -54,12 +54,16 @@ POLARIS_ACTIVE_SEPS = [
 
 # Modules to add to parent project's MIDDLEWARE
 MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.middleware.locale.LocaleMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
+    "polaris.middleware.TimezoneMiddleware",
 ]
 
 SESSION_COOKIE_SECURE = True
@@ -132,7 +136,11 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "verbose": {"format": "{asctime} - {levelname} - {message}", "style": "{",},
+        "verbose": {
+            "format": "{asctime} - {levelname} - {name}:{lineno} - {message}",
+            "style": "{",
+            "datefmt": "%Y-%m-%dT%H:%M:%SZ",
+        },
     },
     "handlers": {
         "console": {


### PR DESCRIPTION
Updates the log message format to include the logger's name (which by convention is equal to the `__name__` python variable) and the line number of the log statement. This also removes the unnecessary subclass of `LogAdapter`.

An unrelated change updates the `polaris/settings.py` file's `MIDDLEWARE` list to match the reference server's list.