### PR TITLE
use 'ANCHOR_QUOTE_SERVER' when stellar.toml is generated

### DIFF
--- a/polaris/polaris/sep1/views.py
+++ b/polaris/polaris/sep1/views.py
@@ -83,7 +83,7 @@ def generate_toml(request: Request) -> Response:
     if "sep-31" in settings.ACTIVE_SEPS:
         toml_dict["DIRECT_PAYMENT_SERVER"] = os.path.join(settings.HOST_URL, "sep31")
     if "sep-38" in settings.ACTIVE_SEPS:
-        toml_dict["QUOTE_SERVER"] = os.path.join(settings.HOST_URL, "sep38")
+        toml_dict["ANCHOR_QUOTE_SERVER"] = os.path.join(settings.HOST_URL, "sep38")
 
     toml_dict.update(registered_toml_func(request))
     content = toml.dumps(toml_dict)

--- a/polaris/polaris/tests/sep1/test_toml.py
+++ b/polaris/polaris/tests/sep1/test_toml.py
@@ -39,6 +39,7 @@ def test_toml_generated(mock_toml_func, client):
     assert "SIGNING_KEY" in toml_data
     assert "KYC_SERVER" in toml_data
     assert "DIRECT_PAYMENT_SERVER" in toml_data
+    assert "ANCHOR_QUOTE_SERVER" in toml_data
     assert toml_data["TRANSFER_SERVER"] != toml_data["TRANSFER_SERVER_SEP0024"]
     assert toml_data["ACCOUNTS"] == [usd.distribution_account]
     assert toml_data["NETWORK_PASSPHRASE"] == settings.STELLAR_NETWORK_PASSPHRASE


### PR DESCRIPTION
When static `stellar.toml` files are not provided by the developer, Polaris generates the `stellar.toml` file itself, but it has been using an incorrect attribute name for SEP-38's base URI.