### PR TITLE
remove deployment CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,20 +13,3 @@ workflows:
           pre-install-steps:
             - run:
                 command: cp .env.example .env
-  build_deploy_publish:
-    jobs:
-      - python/test:
-          pkg-manager: poetry
-          test-tool: pytest
-          pre-install-steps:
-            - run:
-                command: cp .env.example .env
-          filters:
-            branches:
-              only: master
-      - heroku/deploy-via-git:
-          requires:
-            - python/test
-          filters:
-            branches:
-              only: master


### PR DESCRIPTION
We moved to k8s for our deployment, so we no longer need CircleCI to deploy to Heroku.