### PR TITLE
support streaming fee-bump transactions

### DIFF
--- a/polaris/management/commands/watch_transactions.py
+++ b/polaris/management/commands/watch_transactions.py
@@ -187,8 +187,6 @@ class Command(BaseCommand):
                 result_xdr
             ).result.inner_result_pair.result.result.results
 
-        print(op_results, horizon_tx)
-
         payment_data = await cls._find_matching_payment_data(
             response, horizon_tx, op_results, transaction
         )


### PR DESCRIPTION
resolves #653 

This PR adds support for parsing fee-bump transactions in our transaction monitoring process, `watch_transactions`. Previously, sending payments to Polaris anchors using fee-bumps would cause the process to crash and the transaction would never be detected.