### PR TITLE
Fixed calculate_fee parameter type hint

### DIFF
--- a/polaris/integrations/fees.py
+++ b/polaris/integrations/fees.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 from decimal import Decimal
 
 from rest_framework.request import Request
@@ -8,7 +8,7 @@ from polaris.models import Asset
 
 
 def calculate_fee(
-    fee_params: Dict, *_args: List, request: Request = None, **_kwargs: Dict
+    fee_params: Dict, *_args: List, request: Optional[Request] = None, **_kwargs: Dict
 ) -> Decimal:
     """
     .. _`/fee`: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#fee


### PR DESCRIPTION
`calculate_fee` has been generating this type hint error:

![image](https://user-images.githubusercontent.com/26092447/216761179-61fc17ad-5af7-41ea-b7b1-45f5e7211ff4.png)

This PR fixes that error. This is a very minor and optional fix, can be merged in a future release.