### PR TITLE
add publish github action

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+Name: Publish to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11' 
+          cache: poetry
+      - name: Install Package
+        run: poetry install
+      - name: Test Package
+        run: poetry run pytest
+      - name: Build Package Distributions
+        run: poetry build
+      - name: Publish Package Distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a github action for publishing Django Polaris to PyPI on creation of a release. Uses the recommend Trusted Publisher approach for authorization.